### PR TITLE
Bumping up to 0.1.1 Beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, with one section per released version.
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-03-25
+
 ### Added
 - Cumulative library filters for tracking status and media type.
 - Desktop update notifications and changelog prompts for new releases.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kechimochi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kechimochi",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kechimochi",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kechimochi"
-version = "0.1.0"
+version = "0.1.1"
 description = "A personal language immersion tracker"
 authors = ["Morgawr"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kechimochi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.morg.kechimochi",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Testing a release cycle so we can also test update checks with a follow-up 0.1.2 version.