### PR TITLE
Bump version to 0.1.2 Beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, with one section per released version.
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-03-25
+
+- No real updates, I am just writing a changelog to test the update check workflow
+
 ## [0.1.1] - 2026-03-25
 
 ### Added

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -10,8 +10,6 @@ Kechimochi now uses three independent version concepts:
 - Database schema version: an integer stored in SQLite and managed separately from app releases.
 - Backup format version: an integer for full-backup packaging and manifest compatibility.
 
-The current release baseline is `0.1.0`.
-
 These three versions move for different reasons:
 
 - app version changes when the product ships a new release,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kechimochi",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kechimochi",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kechimochi",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kechimochi"
-version = "0.1.1"
+version = "0.1.2"
 description = "A personal language immersion tracker"
 authors = ["Morgawr"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kechimochi",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.morg.kechimochi",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
This is an "empty" release, to test the update check workflow. 