### PR TITLE
css fix for the quick log in tablet mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, with one section per released version.
 
 ## [Unreleased]
 
+### Fixed
+ - Quick log now shows more clearly in tablet mode
+
+
 ## [0.2.5] - 2026-04-08
 
 ### Added

--- a/src/styles.css
+++ b/src/styles.css
@@ -2425,7 +2425,7 @@ input:checked + .slider:before {
   }
 }
 
-@media (max-width: 1024px) and (orientation: portrait) {
+@media (max-width: 1024px)  {
   .quick-log-card {
     gap: 0.7rem !important;
   }


### PR DESCRIPTION
The weird inbetween was caused by the portrait mode on top of width check. Hence why I didn't see it on my pc unless reducing the height. #134 

Now It appears the same way in tablet aspect as in phone aspect.

I also tested this grid layout I don't know if its better (just in case the one I submitted is too big) : 

<img width="1869" height="836" alt="image" src="https://github.com/user-attachments/assets/9a61a0cb-ad22-4bb4-a326-3b4b1ca4e9ff" />