### PR TITLE
fix for the colors not matching in graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog, with one section per released version.
 
 ### Fixed
  - Quick log now shows more clearly in tablet mode
+ - Circle and bar activity graphs now use a consistent color mapping
 
 
 ## [0.2.5] - 2026-04-08

--- a/src/components/dashboard/ActivityCharts.ts
+++ b/src/components/dashboard/ActivityCharts.ts
@@ -346,14 +346,16 @@ export class ActivityCharts extends Component<ActivityChartsState> {
         const activeKeys = this.getActiveKeys(logs, getBucketIndex, groupByMode);
         const datasetsMap = this.aggregateDailyData(logs, activeKeys, getBucketIndex, labels.length, groupByMode);
 
-        return Array.from(datasetsMap.entries()).map(([key, data], i) => ({
-            label: key,
-            data: data,
-            backgroundColor: colors[i % colors.length],
-            borderColor: colors[i % colors.length],
-            fill: chartType === 'line' ? false : undefined,
-            tension: 0.3
-        }));
+        return Array.from(datasetsMap.entries())
+            .sort((a, b) => b[1].reduce((s, v) => s + v, 0) - a[1].reduce((s, v) => s + v, 0))
+            .map(([key, data], i) => ({
+                label: key,
+                data: data,
+                backgroundColor: colors[i % colors.length],
+                borderColor: colors[i % colors.length],
+                fill: chartType === 'line' ? false : undefined,
+                tension: 0.3
+            }));
     }
 
     private getActiveKeys(logs: ActivitySummary[], getBucketIndex: (date: string) => number, mode: 'media_type' | 'log_name'): Set<string> {


### PR DESCRIPTION
fix for #140
the reason was that the circle graph is sorted from biggest to smallest and the colors are applied based on position.
but the bar graph was not sorted at all. so the default order was the log order. I don't know if it was intentional.
If it is, we'll need to implement a map from one of the graphs to get the colors for the other.