### PR TITLE
Prefill Milestone modal from activity totals and update tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on Keep a Changelog, with one section per released version.
  - Quick log now shows more clearly in tablet mode
  - Circle and bar activity graphs now use a consistent color mapping
 
+### Changed
+ - Milestones now pre-fill the textboxes with time and/or char already recorded
 
 ## [0.2.5] - 2026-04-08
 

--- a/e2e/helpers/media-detail.ts
+++ b/e2e/helpers/media-detail.ts
@@ -370,6 +370,19 @@ export async function addMilestone(name: string, hours: string, minutes: string,
     return selectedDate;
 }
 
+export async function getMilestonePrefillValues(): Promise<{ hours: string; minutes: string; characters: string; }> {
+    const overlay = await openMilestoneModal();
+    const hours = await overlay.$('#milestone-hours').getValue();
+    const minutes = await overlay.$('#milestone-minutes').getValue();
+    const characters = await overlay.$('#milestone-characters').getValue();
+
+    await safeClick(() => overlay.$('#milestone-cancel'));
+    await waitForOverlayToDisappear(overlay, 5000);
+    await waitForMilestoneActionToSettle();
+
+    return { hours, minutes, characters };
+}
+
 export async function submitInvalidMilestone(name: string, hours: string, minutes: string, characters: string = '0'): Promise<void> {
     const overlay = await openMilestoneModal();
     await populateMilestoneForm(overlay, { name, hours, minutes, characters });

--- a/e2e/specs/milestone-cuj.spec.ts
+++ b/e2e/specs/milestone-cuj.spec.ts
@@ -2,7 +2,7 @@ import { waitForAppReady } from '../helpers/setup.js';
 import { navigateTo, verifyActiveView } from '../helpers/navigation.js';
 import { addMedia, clickMediaItem } from '../helpers/library.js';
 import { setDialogMockPath, dismissAlert, closeModal } from '../helpers/common.js';
-import { addMilestone, submitInvalidMilestone, deleteMilestoneByName, clearAllMilestones, getMilestoneListText } from '../helpers/media-detail.js';
+import { addMilestone, submitInvalidMilestone, deleteMilestoneByName, clearAllMilestones, getMilestoneListText, logActivityFromDetail, getMilestonePrefillValues } from '../helpers/media-detail.js';
 import { exportMilestones, importMilestones } from '../helpers/profile.js';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -68,14 +68,19 @@ describe('Milestone CUJ Test', () => {
         expect(milestoneListText).toContain('No milestones yet.');
         expect(await $('#btn-clear-milestones').isExisting()).toBe(false);
 
+        // Milestone defaults should be prefilled from current activity totals.
+        await logActivityFromDetail(mediaTitle, '121', '1000');
+        const prefill = await getMilestonePrefillValues();
+        expect(prefill).toEqual({ hours: '2', minutes: '1', characters: '1000' });
+
         // Add standard milestone (121m -> 2h1min)
-        await addMilestone('First Milestone', '0', '121', '0');
+        await addMilestone('First Milestone', prefill.hours, prefill.minutes, prefill.characters);
 
         await browser.waitUntil(async () => {
             const firstMilestone = $(`.milestone-item[data-milestone-name="First Milestone"]`);
             if (!(await firstMilestone.isExisting())) return false;
             const text = await firstMilestone.getText();
-            return text.includes('2h1min');
+            return text.includes('2h1min') && /1,?000 chars/.test(text);
         }, { timeout: 5000, interval: 100, timeoutMsg: 'Milestone "First Milestone" did not show expected duration' });
 
         expect(await $('#btn-clear-milestones').isDisplayed()).toBe(true);

--- a/src/components/media/MediaDetail.ts
+++ b/src/components/media/MediaDetail.ts
@@ -760,7 +760,12 @@ export class MediaDetail extends Component<MediaDetailState> {
         });
 
         root.querySelector('#btn-add-milestone')?.addEventListener('click', async () => {
-            const milestone = await showAddMilestoneModal(this.state.media.title);
+            const currentDuration = this.state.logs.reduce((acc, log) => acc + log.duration_minutes, 0);
+            const currentCharacters = this.state.logs.reduce((acc, log) => acc + log.characters, 0);
+            const milestone = await showAddMilestoneModal(this.state.media.title, {
+                duration: currentDuration,
+                characters: currentCharacters
+            });
             if (milestone) {
                 try {
                     await addMilestone(milestone);

--- a/src/modals/milestone.ts
+++ b/src/modals/milestone.ts
@@ -2,9 +2,18 @@ import { Milestone } from '../api';
 import { buildCalendar } from './calendar';
 import { createOverlay, customAlert } from './base';
 
-export async function showAddMilestoneModal(mediaTitle: string): Promise<Milestone | null> {
+type MilestoneDefaults = {
+    duration?: number;
+    characters?: number;
+};
+
+export async function showAddMilestoneModal(mediaTitle: string, defaults?: MilestoneDefaults): Promise<Milestone | null> {
     return new Promise((resolve) => {
         const { overlay, cleanup: baseCleanup } = createOverlay();
+        const initialDuration = Math.max(0, Math.floor(defaults?.duration ?? 0));
+        const initialCharacters = Math.max(0, Math.floor(defaults?.characters ?? 0));
+        const initialHours = Math.floor(initialDuration / 60);
+        const initialMinutes = initialDuration % 60;
         
         const today = new Date().toISOString().split('T')[0];
         let selectedDate: string | undefined = undefined;
@@ -38,16 +47,16 @@ export async function showAddMilestoneModal(mediaTitle: string): Promise<Milesto
                     <div style="display: flex; flex-direction: column; gap: 0.3rem;">
                         <label style="font-size: 0.85rem; color: var(--text-secondary);">Duration</label>
                         <div style="display: flex; align-items: center; gap: 0.5rem;">
-                            <input type="number" id="milestone-hours" class="milestone-input" value="0" min="0" style="width: 70px; background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-color); padding: 0.5rem; border-radius: var(--radius-sm); text-align: center;" />
+                            <input type="number" id="milestone-hours" class="milestone-input" value="${initialHours}" min="0" style="width: 70px; background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-color); padding: 0.5rem; border-radius: var(--radius-sm); text-align: center;" />
                             <span style="font-size: 0.85rem;">h</span>
-                            <input type="number" id="milestone-minutes" class="milestone-input" value="0" min="0" style="width: 70px; background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-color); padding: 0.5rem; border-radius: var(--radius-sm); text-align: center;" />
+                            <input type="number" id="milestone-minutes" class="milestone-input" value="${initialMinutes}" min="0" style="width: 70px; background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-color); padding: 0.5rem; border-radius: var(--radius-sm); text-align: center;" />
                             <span style="font-size: 0.85rem;">m</span>
                         </div>
                     </div>
 
                     <div style="display: flex; flex-direction: column; gap: 0.3rem;">
                         <label style="font-size: 0.85rem; color: var(--text-secondary);">Characters</label>
-                        <input type="number" id="milestone-characters" class="milestone-input" value="0" min="0" style="background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-color); padding: 0.5rem; border-radius: var(--radius-sm);" />
+                        <input type="number" id="milestone-characters" class="milestone-input" value="${initialCharacters}" min="0" style="background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-color); padding: 0.5rem; border-radius: var(--radius-sm);" />
                     </div>
 
                     <div style="display: flex; flex-direction: column; gap: 0.5rem;">

--- a/tests/components/media/MediaDetail.test.ts
+++ b/tests/components/media/MediaDetail.test.ts
@@ -233,8 +233,12 @@ describe('MediaDetail', () => {
         vi.mocked(api.getMilestones).mockResolvedValue([]);
         const newMilestone = { name: 'M1', duration: 100 };
         vi.mocked(modals.showAddMilestoneModal).mockResolvedValue(newMilestone as unknown as Milestone);
+        const logs = [
+            { id: 1, duration_minutes: 40, characters: 200, date: '2024-03-01', media_id: 1, title: 'T1', media_type: 'Reading', language: 'Japanese' },
+            { id: 2, duration_minutes: 20, characters: 300, date: '2024-03-02', media_id: 1, title: 'T1', media_type: 'Reading', language: 'Japanese' }
+        ] as unknown as api.ActivitySummary[];
 
-        const component = new MediaDetail(container, { ...mockMedia } as unknown as Media, [], [mockMedia as unknown as Media], 0, mockCallbacks);
+        const component = new MediaDetail(container, { ...mockMedia } as unknown as Media, logs, [mockMedia as unknown as Media], 0, mockCallbacks);
         component.triggerMount();
         component.render();
 
@@ -242,7 +246,7 @@ describe('MediaDetail', () => {
         addBtn.click();
 
         await vi.waitFor(() => {
-            expect(modals.showAddMilestoneModal).toHaveBeenCalled();
+            expect(modals.showAddMilestoneModal).toHaveBeenCalledWith('Test Media', { duration: 60, characters: 500 });
             expect(api.addMilestone).toHaveBeenCalledWith(newMilestone);
         });
     });

--- a/tests/modals/milestone.test.ts
+++ b/tests/modals/milestone.test.ts
@@ -62,4 +62,17 @@ describe('modals/milestone.ts', () => {
         const result = await promise;
         expect(result).toBeNull();
     });
+
+    it('should prefill duration and characters from defaults', async () => {
+        showAddMilestoneModal('Test Media', { duration: 125, characters: 3210 });
+        await vi.waitFor(() => document.querySelector('#milestone-hours'));
+
+        const hoursInput = document.querySelector('#milestone-hours') as HTMLInputElement;
+        const minutesInput = document.querySelector('#milestone-minutes') as HTMLInputElement;
+        const charactersInput = document.querySelector('#milestone-characters') as HTMLInputElement;
+
+        expect(hoursInput.value).toBe('2');
+        expect(minutesInput.value).toBe('5');
+        expect(charactersInput.value).toBe('3210');
+    });
 });


### PR DESCRIPTION
### Motivation

- Provide sensible defaults in the "Add Milestone" modal based on the current activity totals so users don't have to re-enter recent totals. 
- Surface those prefilled values to tests so e2e flows can assert the UI prefill behavior.

### Description

- Added an optional `defaults` parameter to `showAddMilestoneModal(mediaTitle, defaults?)` and compute initial `hours`, `minutes`, and `characters` from `defaults.duration` and `defaults.characters` in the modal markup. 
- Updated `MediaDetail` to compute `currentDuration` and `currentCharacters` from `this.state.logs` and pass them as defaults when opening the milestone modal. 
- Added `getMilestonePrefillValues()` helper in `e2e/helpers/media-detail.ts` to read the prefilled values from the modal and close it, for use in tests. 
- Updated tests to assert the new behavior: modified component test to expect `showAddMilestoneModal` to be called with defaults, added a modal unit test to verify prefill computation, and updated the e2e spec to log activity, read prefill values, and use them when adding milestones.

### Testing

- Ran the unit/component/modal test suite with `vitest` and the updated tests passed, including the new prefill test in `tests/modals/milestone.test.ts` and the `MediaDetail` component test changes. 
- Updated e2e spec `e2e/specs/milestone-cuj.spec.ts` and added `getMilestonePrefillValues()` to the helpers for use in CI; e2e tests were prepared but not executed in this patch run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd3ce77dc8330bf73a034399c3dee)