### PR TITLE
Fix media pagination not reloading logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on Keep a Changelog, with one section per released version.
 ### Fixed
  - Some elements are now readable in light themes including : Desktop window title, activity breakdown legend, android top bar.
  - Patch notes should now show long bullet lists with the right indentation
+ - Changing media using the pagination now properly loads the logs.
 
 ## [0.2.9] - 2026-05-09
 

--- a/src/media/MediaView.ts
+++ b/src/media/MediaView.ts
@@ -38,6 +38,7 @@ export class MediaView extends Component<MediaViewState> {
     private gridSupportQuery: MediaQueryList | null = null;
     private isDestroyed = false;
     private navigationSource?:  'dashboard' | 'timeline';
+    private detailNavigationRequestId = 0;
 
     constructor(container: HTMLElement) {
         super(container, {
@@ -167,7 +168,28 @@ export class MediaView extends Component<MediaViewState> {
         if (currentMediaList.length === 0) return;
 
         const nextIndex = (currentIndex + direction + currentMediaList.length) % currentMediaList.length;
-        this.setState({ currentIndex: nextIndex });
+        await this.navigateToDetailIndex(nextIndex);
+    }
+
+    private async navigateToDetailIndex(nextIndex: number) {
+        const media = this.state.currentMediaList[nextIndex];
+        if (!media) return;
+
+        const requestId = ++this.detailNavigationRequestId;
+        this.setState({ currentIndex: nextIndex, currentLogs: [] });
+
+        if (typeof media.id !== 'number') return;
+
+        try {
+            const currentLogs = await getLogsForMedia(media.id);
+            if (this.isDestroyed || requestId !== this.detailNavigationRequestId) return;
+            this.setState({ currentLogs });
+        } catch (e) {
+            Logger.error('Failed to load logs for media detail navigation', e);
+            if (!this.isDestroyed && requestId === this.detailNavigationRequestId) {
+                this.setState({ currentLogs: [] });
+            }
+        }
     }
 
     private async exitDetail(shouldRefresh: boolean = false) {
@@ -439,7 +461,7 @@ private async handleBack() {
                 onBackToLibrary: () => { this.runAsync(this.handleBackToLibrary(), 'Failed to navigate back to library'); },
                 onNext: () => { this.runAsync(this.navigateDetail(1), 'Failed to navigate to next media'); },
                 onPrev: () => { this.runAsync(this.navigateDetail(-1), 'Failed to navigate to previous media'); },
-                onNavigate: (index) => this.setState({ currentIndex: index }),
+                onNavigate: (index) => { this.runAsync(this.navigateToDetailIndex(index), 'Failed to navigate to selected media'); },
                 onDelete: () => { this.runAsync(this.exitDetail(true), 'Failed to refresh library after delete'); },
             },
         );

--- a/tests/components/media_view.test.ts
+++ b/tests/components/media_view.test.ts
@@ -241,6 +241,56 @@ describe('MediaView', () => {
         await vi.waitFor(() => expect(component.state.viewMode).toBe('grid'));
     });
 
+    it('reloads detail logs when navigating between media', async () => {
+        const mockMedia = [{ id: 10, title: 'Old' }, { id: 20, title: 'New' }];
+        const oldLogs = [{
+            id: 1,
+            media_id: 10,
+            title: 'Old',
+            media_type: 'Reading',
+            duration_minutes: 30,
+            characters: 1000,
+            date: '2026-01-01',
+            language: 'Japanese',
+        }];
+        const newLogs = [{
+            id: 2,
+            media_id: 20,
+            title: 'New',
+            media_type: 'Reading',
+            duration_minutes: 45,
+            characters: 2000,
+            date: '2026-01-02',
+            language: 'Japanese',
+        }];
+        vi.mocked(api.getAllMedia).mockResolvedValue(mockMedia as unknown as Media[]);
+        vi.mocked(api.getLogsForMedia).mockImplementation(async (mediaId: number) => (
+            mediaId === 10 ? oldLogs : newLogs
+        ) as api.ActivitySummary[]);
+
+        const component = new MediaView(container);
+        await renderAndWaitForBrowser(component);
+
+        const onSelect = vi.mocked(MediaLibraryBrowser).mock.calls[0][2];
+        onSelect(10);
+
+        await vi.waitFor(() => {
+            const detailProps = vi.mocked(MediaDetail).mock.calls.at(-1);
+            expect(detailProps?.[1]).toEqual(expect.objectContaining({ id: 10 }));
+            expect(detailProps?.[2]).toEqual(oldLogs);
+        });
+
+        const detailCallbacks = vi.mocked(MediaDetail).mock.calls.at(-1)?.[5];
+        detailCallbacks.onNext();
+
+        await vi.waitFor(() => {
+            const detailProps = vi.mocked(MediaDetail).mock.calls.at(-1);
+            expect(api.getLogsForMedia).toHaveBeenCalledWith(20);
+            expect(detailProps?.[1]).toEqual(expect.objectContaining({ id: 20 }));
+            expect(detailProps?.[2]).toEqual(newLogs);
+        });
+    });
+
     it('ignores keyboard shortcuts when focus is in an editable field and handles keyboard navigation otherwise', async () => {
         const mockMedia = [{ id: 10, title: 'T1' }, { id: 20, title: 'T2' }];
         vi.mocked(api.getAllMedia).mockResolvedValue(mockMedia as unknown as Media[]);


### PR DESCRIPTION
I noticed this bug, when changing media from the pagination at the top, the "recent logs" wouldn't update, so the extradata was all wrong, and estimates wouldn't update too. 

I checked if the previous release had it, and It did, so I added it in "fixed" in the changelog.