### PR TITLE
Activity Visualization: "Monthly" graph labels (closes #86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,14 @@ The format is based on Keep a Changelog, with one section per released version.
  - Adjusted a few colors in themes : Purple, Yellow lime, Deep blue, to have more readable buttons.
  - Made quick log display 6 elements on desktop and large mobiles.
  - Made loading of Medias faster when clicking from library and quick log shortcuts.
+ - Monthly activity visualisation now labels bars with their date range (e.g. "Jun 1–7") instead of generic "Week 1 / Week 2".
 
 ### Fixed
  - Some elements are now readable in light themes including : Desktop window title, activity breakdown legend, android top bar.
  - Patch notes should now show long bullet lists with the right indentation
  - Changing media using the pagination now properly loads the logs.
+ - The activity visualisation "next period" navigation button is now clearly greyed out when already viewing the current period, instead of appearing active but doing nothing.
+ - Monthly activity visualisation no longer drops activity from the final partial week in some months.
 
 ## [0.2.9] - 2026-05-09
 

--- a/src/dashboard/ActivityCharts.ts
+++ b/src/dashboard/ActivityCharts.ts
@@ -44,7 +44,7 @@ export class ActivityCharts extends Component<ActivityChartsState> {
                                     <path d="M10 4l-4 4 4 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                 </svg>
                             </button>
-                            <h3 class="activity-charts-title dashboard-module-title">Activity visualization</h3>
+                            <h3 class="activity-charts-title dashboard-module-title">Activity Visualization</h3>
                             <button class="btn btn-ghost chart-nav-button" id="btn-chart-next">
                                 <svg class="nav-svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
                                     <path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/src/dashboard/activity_ranges.ts
+++ b/src/dashboard/activity_ranges.ts
@@ -1,5 +1,7 @@
 import { ActivitySummary } from '../api';
 
+const MONTH_ABBREVIATIONS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
 export const ACTIVITY_TIME_RANGES = {
     ALL_TIME: 0,
     WEEKLY: 7,
@@ -75,14 +77,19 @@ function getMonthlyRange(timeRangeOffset: number): ActivityRange {
     const validEnd = getLocalISODate(endDay);
 
     const weeksCount = Math.ceil(endDay.getDate() / 7);
-    for (let i = 0; i < weeksCount; i++) labels.push(`Week ${i + 1}`);
+    for (let i = 0; i < weeksCount; i++) {
+        const blockStart = i * 7 + 1;
+        const blockEnd = Math.min(endDay.getDate(), i * 7 + 7);
+        const label = blockStart === blockEnd
+            ? `${MONTH_ABBREVIATIONS[m]} ${blockStart}`
+            : `${MONTH_ABBREVIATIONS[m]} ${blockStart}–${blockEnd}`;
+        labels.push(label);
+    }
 
     const getBucketIndex = (dateStr: string) => {
         if (dateStr >= validStart && dateStr <= validEnd) {
-            const date = new Date(dateStr + 'T00:00:00');
-            const firstDayWeekday = startDay.getDay();
-            const offset = firstDayWeekday === 0 ? 6 : firstDayWeekday - 1;
-            return Math.floor((date.getDate() + offset - 1) / 7);
+            const day = new Date(dateStr + 'T00:00:00').getDate();
+            return Math.floor((day - 1) / 7);
         }
         return -1;
     };
@@ -94,7 +101,7 @@ function getYearlyRange(timeRangeOffset: number): ActivityRange {
     const targetYear = new Date().getFullYear() - timeRangeOffset;
     const validStart = `${targetYear}-01-01`;
     const validEnd = `${targetYear}-12-31`;
-    const labels = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const labels = MONTH_ABBREVIATIONS.slice();
 
     const getBucketIndex = (dateStr: string) => {
         if (dateStr >= validStart && dateStr <= validEnd) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3972,8 +3972,8 @@ button:hover{
   padding: 0;
   height: 2rem;
 }
-.single-char-btn:disabled{
-
+.single-char-btn:disabled,
+.chart-nav-button:disabled {
   opacity: 50%;
   pointer-events: none;
   cursor: not-allowed;

--- a/tests/components/dashboard/activity_ranges.test.ts
+++ b/tests/components/dashboard/activity_ranges.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getActivityRange, ACTIVITY_TIME_RANGES } from '../../../src/dashboard/activity_ranges';
+
+describe('getActivityRange — monthly', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('produces correct date-range labels for June 2026 (30-day month)', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-15T12:00:00'));
+
+        const range = getActivityRange(ACTIVITY_TIME_RANGES.MONTHLY, 0);
+
+        expect(range.labels).toEqual([
+            'Jun 1–7',
+            'Jun 8–14',
+            'Jun 15–21',
+            'Jun 22–28',
+            'Jun 29–30',
+        ]);
+    });
+
+    it('maps June 2026 dates to correct bucket indexes', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-15T12:00:00'));
+
+        const range = getActivityRange(ACTIVITY_TIME_RANGES.MONTHLY, 0);
+
+        expect(range.getBucketIndex('2026-06-01')).toBe(0);
+        expect(range.getBucketIndex('2026-06-07')).toBe(0);
+        expect(range.getBucketIndex('2026-06-08')).toBe(1);
+        expect(range.getBucketIndex('2026-06-14')).toBe(1);
+        expect(range.getBucketIndex('2026-06-30')).toBe(4);
+        expect(range.getBucketIndex('2026-05-31')).toBe(-1);
+        expect(range.getBucketIndex('2026-07-01')).toBe(-1);
+    });
+
+    it('produces correct labels and bucket indexes for a 31-day month (July 2026)', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-15T12:00:00'));
+
+        const range = getActivityRange(ACTIVITY_TIME_RANGES.MONTHLY, 0);
+
+        expect(range.labels).toEqual([
+            'Jul 1–7',
+            'Jul 8–14',
+            'Jul 15–21',
+            'Jul 22–28',
+            'Jul 29–31',
+        ]);
+        expect(range.labels.length).toBe(5);
+        expect(range.getBucketIndex('2026-07-31')).toBe(4);
+    });
+
+    it('produces correct labels for February 2026 (28-day month)', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-02-15T12:00:00'));
+
+        const range = getActivityRange(ACTIVITY_TIME_RANGES.MONTHLY, 0);
+
+        expect(range.labels).toEqual([
+            'Feb 1–7',
+            'Feb 8–14',
+            'Feb 15–21',
+            'Feb 22–28',
+        ]);
+        expect(range.labels.length).toBe(4);
+        expect(range.getBucketIndex('2026-02-28')).toBe(3);
+    });
+});


### PR DESCRIPTION
Closes #86 

PR alters the graph labeling as mentioned in the original issue. I don't use lingotrack myself, so do not know how they do it. I went for directly translating "Week 1", "Week 2" into "Jun 1-7", "Jun 8-14", and so on. That is, a week is not considered "from Monday to Sunday, and cut off if outside month", but rather that we always go by seven-day weeks until the month's remainder at the end (e.g. "Jun 29-30"). Comes down to personal preference what kind of system one wants. If this doesn't spark joy, then tell me what kind of formatting it should be.

Besides that, three minor bug fixes.
- There were two different week-bucketing schemes: activity_ranges.getBucketIndex and ActivityTotals.getWeekBucketRange. The prior was altered so the scheme is unified.
- The header "Activity visualization" is now capitalized as "Activity Visualization" to match the other headers of the Dashboard widgets.
- The "next" button in the Activity Visualization widget was alreaedy functionally disabled if the currently displayed date range included today, but didn't get "disabled" type CSS styling. It has been added to an existing :disabled rule.