### PR TITLE
Bug: Heatmap character coloring (closes #201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on Keep a Changelog, with one section per released version.
 
 ## [Unreleased]
 
+### Fixed
+ - The tracking heatmap now colors days that have characters logged but no time tracked, in addition to days with time tracked. Cell intensity reflects whichever of the two is higher, so days tracked with both time and characters are not artificially brighter.
+
 ## [0.2.10] - 2026-06-10
 
 ### Added

--- a/src/dashboard/HeatmapView.ts
+++ b/src/dashboard/HeatmapView.ts
@@ -2,6 +2,16 @@ import { Component } from '../component';
 import { html } from '../html';
 import { DailyHeatmap } from '../api';
 
+// A day reaches full heatmap intensity at 6 hours of time, or 60,000 characters.
+// This assumes an average-ish learner reading at ~10,000 characters/hour.
+const HEATMAP_FULL_INTENSITY_MINUTES = 360;
+const HEATMAP_FULL_INTENSITY_CHARACTERS = 60000;
+
+function getIntensityRatio(value: number, fullIntensityValue: number): number {
+    if (value <= 0) return 0;
+    return Math.min(1, (value - 1) / (fullIntensityValue - 1));
+}
+
 interface HeatmapViewState {
     heatmapData: DailyHeatmap[];
     year: number;
@@ -142,10 +152,12 @@ export class HeatmapView extends Component<HeatmapViewState> {
         }
     ): string {
         const cellStyles: string[] = [];
-        if (minutes > 0) {
-            const ratio = Math.min(1, (minutes - 1) / 359);
-            const saturation = theme.satBase + (ratio * theme.satRange);
-            const lightness = theme.lightBase + (ratio * theme.lightRange);
+        const timeRatio = getIntensityRatio(minutes, HEATMAP_FULL_INTENSITY_MINUTES);
+        const characterRatio = getIntensityRatio(characters, HEATMAP_FULL_INTENSITY_CHARACTERS);
+        const higherRatio = Math.max(timeRatio, characterRatio);
+        if (minutes > 0 || characters > 0) {
+            const saturation = theme.satBase + (higherRatio * theme.satRange);
+            const lightness = theme.lightBase + (higherRatio * theme.lightRange);
             cellStyles.push(`background-color: hsl(${theme.heatmapHue}, ${saturation}%, ${lightness}%);`);
         }
 

--- a/tests/components/dashboard/HeatmapView.test.ts
+++ b/tests/components/dashboard/HeatmapView.test.ts
@@ -63,7 +63,7 @@ describe('HeatmapView', () => {
         expect(container.textContent).toContain('No data recorded yet');
     });
 
-    it('should color a character-only day (core bug fix)', () => {
+    it('should color a character-only day', () => {
         const heatmapData = [
             { date: '2024-01-01', total_minutes: 0, total_characters: 5000 }
         ];
@@ -76,7 +76,7 @@ describe('HeatmapView', () => {
         expect(styleAttribute).toContain('background-color: hsl(');
     });
 
-    it('should still color a time-only day (regression)', () => {
+    it('should color a time-only day', () => {
         const heatmapData = [
             { date: '2024-01-01', total_minutes: 60, total_characters: 0 }
         ];
@@ -89,7 +89,7 @@ describe('HeatmapView', () => {
         expect(styleAttribute).toContain('background-color: hsl(');
     });
 
-    it('should use the hotter of time and character ratios (no double-heat)', () => {
+    it('should use the hotter of time and character ratios', () => {
         const hslSaturationPattern = /background-color:\s*hsl\(\s*[\d.]+\s*,\s*([\d.]+)%/;
 
         // High-character + low-time day: character ratio dominates
@@ -136,7 +136,7 @@ describe('HeatmapView', () => {
         expect(bothTrackedSaturation).toBe(highCharacterSaturation);
     });
 
-    it('should produce higher saturation for more characters (monotonic ramp)', () => {
+    it('should produce higher saturation for more characters', () => {
         const hslSaturationPattern = /background-color:\s*hsl\(\s*[\d.]+\s*,\s*([\d.]+)%/;
 
         const lowCharacterData = [

--- a/tests/components/dashboard/HeatmapView.test.ts
+++ b/tests/components/dashboard/HeatmapView.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { HeatmapView } from '../../../src/dashboard/HeatmapView';
+import { HeatmapView } from '../../../src/dashboard';
 
 describe('HeatmapView', () => {
     let container: HTMLElement;
@@ -61,5 +61,109 @@ describe('HeatmapView', () => {
         const component = new HeatmapView(container, { heatmapData: [], year: Number.NaN }, onYearChange);
         component.render();
         expect(container.textContent).toContain('No data recorded yet');
+    });
+
+    it('should color a character-only day (core bug fix)', () => {
+        const heatmapData = [
+            { date: '2024-01-01', total_minutes: 0, total_characters: 5000 }
+        ];
+        const component = new HeatmapView(container, { heatmapData, year: 2024 }, onYearChange);
+        component.render();
+
+        const cell = container.querySelector('.heatmap-cell[title*="2024-01-01"]') as HTMLElement;
+        expect(cell).not.toBeNull();
+        const styleAttribute = cell.getAttribute('style') ?? '';
+        expect(styleAttribute).toContain('background-color: hsl(');
+    });
+
+    it('should still color a time-only day (regression)', () => {
+        const heatmapData = [
+            { date: '2024-01-01', total_minutes: 60, total_characters: 0 }
+        ];
+        const component = new HeatmapView(container, { heatmapData, year: 2024 }, onYearChange);
+        component.render();
+
+        const cell = container.querySelector('.heatmap-cell[title*="2024-01-01"]') as HTMLElement;
+        expect(cell).not.toBeNull();
+        const styleAttribute = cell.getAttribute('style') ?? '';
+        expect(styleAttribute).toContain('background-color: hsl(');
+    });
+
+    it('should use the hotter of time and character ratios (no double-heat)', () => {
+        const hslSaturationPattern = /background-color:\s*hsl\(\s*[\d.]+\s*,\s*([\d.]+)%/;
+
+        // High-character + low-time day: character ratio dominates
+        const highCharacterData = [
+            { date: '2024-01-01', total_minutes: 10, total_characters: 30000 }
+        ];
+        const highCharacterComponent = new HeatmapView(
+            container, { heatmapData: highCharacterData, year: 2024 }, onYearChange
+        );
+        highCharacterComponent.render();
+        const highCharacterCell = container.querySelector('.heatmap-cell[title*="2024-01-01"]') as HTMLElement;
+        const highCharacterStyle = highCharacterCell.getAttribute('style') ?? '';
+        const highCharacterSaturation = parseFloat(hslSaturationPattern.exec(highCharacterStyle)?.[1] ?? '0');
+
+        // Same minutes, no characters: time ratio only
+        container.innerHTML = '';
+        const timeOnlyData = [
+            { date: '2024-01-01', total_minutes: 10, total_characters: 0 }
+        ];
+        const timeOnlyComponent = new HeatmapView(
+            container, { heatmapData: timeOnlyData, year: 2024 }, onYearChange
+        );
+        timeOnlyComponent.render();
+        const timeOnlyCell = container.querySelector('.heatmap-cell[title*="2024-01-01"]') as HTMLElement;
+        const timeOnlyStyle = timeOnlyCell.getAttribute('style') ?? '';
+        const timeOnlySaturation = parseFloat(hslSaturationPattern.exec(timeOnlyStyle)?.[1] ?? '0');
+
+        // The high-character day should be hotter (higher saturation)
+        expect(highCharacterSaturation).toBeGreaterThan(timeOnlySaturation);
+
+        // A both-tracked day with the same characters should match the character-only day (no extra heat)
+        container.innerHTML = '';
+        const bothTrackedData = [
+            { date: '2024-01-01', total_minutes: 10, total_characters: 30000 }
+        ];
+        const bothTrackedComponent = new HeatmapView(
+            container, { heatmapData: bothTrackedData, year: 2024 }, onYearChange
+        );
+        bothTrackedComponent.render();
+        const bothTrackedCell = container.querySelector('.heatmap-cell[title*="2024-01-01"]') as HTMLElement;
+        const bothTrackedStyle = bothTrackedCell.getAttribute('style') ?? '';
+        const bothTrackedSaturation = parseFloat(hslSaturationPattern.exec(bothTrackedStyle)?.[1] ?? '0');
+
+        expect(bothTrackedSaturation).toBe(highCharacterSaturation);
+    });
+
+    it('should produce higher saturation for more characters (monotonic ramp)', () => {
+        const hslSaturationPattern = /background-color:\s*hsl\(\s*[\d.]+\s*,\s*([\d.]+)%/;
+
+        const lowCharacterData = [
+            { date: '2024-01-01', total_minutes: 0, total_characters: 5000 }
+        ];
+        const lowCharacterComponent = new HeatmapView(
+            container, { heatmapData: lowCharacterData, year: 2024 }, onYearChange
+        );
+        lowCharacterComponent.render();
+        const lowCharacterCell = container.querySelector('.heatmap-cell[title*="2024-01-01"]') as HTMLElement;
+        const lowCharacterSaturation = parseFloat(
+            hslSaturationPattern.exec(lowCharacterCell.getAttribute('style') ?? '')?.[1] ?? '0'
+        );
+
+        container.innerHTML = '';
+        const highCharacterData = [
+            { date: '2024-01-01', total_minutes: 0, total_characters: 60000 }
+        ];
+        const highCharacterComponent = new HeatmapView(
+            container, { heatmapData: highCharacterData, year: 2024 }, onYearChange
+        );
+        highCharacterComponent.render();
+        const highCharacterCell = container.querySelector('.heatmap-cell[title*="2024-01-01"]') as HTMLElement;
+        const highCharacterSaturation = parseFloat(
+            hslSaturationPattern.exec(highCharacterCell.getAttribute('style') ?? '')?.[1] ?? '0'
+        );
+
+        expect(highCharacterSaturation).toBeGreaterThan(lowCharacterSaturation);
     });
 });


### PR DESCRIPTION
Closes #201 

Heatmap days are now colored both by time and by characters tracked on some day. The old time max (where peak "heat" is reached) was 360 minutes / six hours. The newly introduced max for characters is 60000 characters, based on a reading speed of roughly 10000 characters per hour to match the time max - seemed reasonable to me, but easy to adjust if this figure seems off. It'll be far too much for some and far too little for others, but I don't think there is a great way to fix this.

We also get a "heat ratio" both for tracked time and tracked characters individually, then take the Math.Max of these two so someone tracking both time *and* characters does not get duplicated heat.