### PR TITLE
Feature: Notes on media entries (closes #25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on Keep a Changelog, with one section per released version.
 
 ## [Unreleased]
 
+### Added
+ - Added a Notes field to activity log entries (editable in the log modal, shown on the media detail page, included in sync and CSV export).
+
 ## [0.2.10] - 2026-06-10
 
 ### Added

--- a/e2e/helpers/sync-mock.ts
+++ b/e2e/helpers/sync-mock.ts
@@ -598,7 +598,7 @@ export function seedRemoteSyncProfile(options?: {
 
     const snapshot: SyncSnapshot = {
         sync_protocol_version: 1,
-        db_schema_version: 2,
+        db_schema_version: 3,
         snapshot_id: snapshotId,
         created_at: createdAt,
         created_by_device_id: REMOTE_DEVICE_ID,

--- a/e2e/specs/startup-schema-mismatch.spec.ts
+++ b/e2e/specs/startup-schema-mismatch.spec.ts
@@ -13,7 +13,7 @@ describe('Startup Error Handling', () => {
     await alertBody.waitForDisplayed({ timeout: STARTUP_ERROR_TIMEOUT_MS });
 
     const alertText = await alertBody.getText();
-    expect(alertText).toContain('Database schema version 999 is newer than this app supports (2)');
+    expect(alertText).toContain('Database schema version 999 is newer than this app supports (3)');
 
     const bodyText = await $('body').getText();
     expect(bodyText).toContain('Unsupported database version');

--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -387,6 +387,7 @@ fn rollback_backup(app_dir: &Path, backup_dir: &Path, files: &[&str]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models;
 
     fn unique_temp_dir(prefix: &str) -> std::path::PathBuf {
         let ts = std::time::SystemTime::now()
@@ -594,6 +595,70 @@ mod tests {
         assert_eq!(logs.len(), 1);
         assert_eq!(logs[0].title, "Legacy VN");
         assert_eq!(logs[0].duration_minutes, 45);
+
+        fs::remove_dir_all(source_dir).ok();
+        fs::remove_dir_all(target_dir).ok();
+    }
+
+    #[test]
+    fn test_backup_export_import_preserves_activity_notes() {
+        let source_dir = unique_temp_dir("backup_notes_source");
+        let target_dir = unique_temp_dir("backup_notes_target");
+        fs::create_dir_all(&source_dir).unwrap();
+        fs::create_dir_all(&target_dir).unwrap();
+
+        // Build source DB with a log that has notes
+        let source_conn = db::init_db(source_dir.clone(), None).unwrap();
+        let media_id = db::add_media_with_id(
+            &source_conn,
+            &models::Media {
+                id: None,
+                uid: None,
+                title: "Backup Notes Media".to_string(),
+                media_type: "Reading".to_string(),
+                status: "Active".to_string(),
+                language: "Japanese".to_string(),
+                description: String::new(),
+                cover_image: String::new(),
+                extra_data: "{}".to_string(),
+                content_type: "Novel".to_string(),
+                tracking_status: "Ongoing".to_string(),
+            },
+        )
+        .unwrap();
+        db::add_log(
+            &source_conn,
+            &models::ActivityLog {
+                id: None,
+                media_id,
+                duration_minutes: 50,
+                characters: 0,
+                date: "2024-11-01".to_string(),
+                activity_type: "Reading".to_string(),
+                notes: "backup note content".to_string(),
+            },
+        )
+        .unwrap();
+
+        let zip_path = source_dir.join("notes_backup.zip");
+        export_full_backup_internal(
+            &source_dir,
+            &source_conn,
+            zip_path.to_str().unwrap(),
+            "{}",
+            "0.0.0",
+        )
+        .unwrap();
+
+        // Import the backup into a fresh connection
+        let mut target_conn = Connection::open_in_memory().unwrap();
+        import_full_backup_internal(&target_dir, &mut target_conn, zip_path.to_str().unwrap())
+            .unwrap();
+
+        let logs = db::get_logs(&target_conn).unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].notes, "backup note content");
+        assert_eq!(logs[0].title, "Backup Notes Media");
 
         fs::remove_dir_all(source_dir).ok();
         fs::remove_dir_all(target_dir).ok();

--- a/src-tauri/src/bin/web_server.rs
+++ b/src-tauri/src/bin/web_server.rs
@@ -997,6 +997,7 @@ mod tests {
                     characters: 0,
                     date: "2024-01-01".to_string(),
                     activity_type: String::new(),
+                    notes: String::new(),
                 },
             )
             .unwrap();
@@ -1009,6 +1010,7 @@ mod tests {
                     characters: 0,
                     date: "2024-01-02".to_string(),
                     activity_type: String::new(),
+                    notes: String::new(),
                 },
             )
             .unwrap();
@@ -1053,6 +1055,7 @@ mod tests {
                     characters: 1500,
                     date: "2024-03-01".to_string(),
                     activity_type: "Reading".to_string(),
+                    notes: String::new(),
                 },
             )
             .unwrap();
@@ -1183,6 +1186,7 @@ mod tests {
                     characters: 0,
                     date: "2024-03-01".to_string(),
                     activity_type: String::new(),
+                    notes: String::new(),
                 },
             )
             .unwrap();

--- a/src-tauri/src/csv_import.rs
+++ b/src-tauri/src/csv_import.rs
@@ -25,6 +25,8 @@ struct CsvRow {
     characters: Option<i64>,
     #[serde(rename = "Activity Type", default)]
     activity_type: Option<String>,
+    #[serde(rename = "Notes", default)]
+    notes: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -143,6 +145,7 @@ pub fn import_csv_from_reader<R: Read>(conn: &mut Connection, reader: R) -> Resu
                 .activity_type
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| record.media_type.clone()),
+            notes: record.notes.unwrap_or_default(),
         };
 
         match db::add_log(&tx, &new_log) {
@@ -235,6 +238,7 @@ pub fn export_logs_csv(
         "Language",
         "Characters",
         "Activity Type",
+        "Notes",
     ])
     .map_err(|e| e.to_string())?;
 
@@ -258,6 +262,7 @@ pub fn export_logs_csv(
             &log.language,
             &log.characters.to_string(),
             &log.media_type,
+            &log.notes,
         ])
         .map_err(|e| e.to_string())?;
 
@@ -689,6 +694,7 @@ mod tests {
                 characters: 100,
                 date: "2024-01-01".to_string(),
                 activity_type: "Reading".to_string(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -701,6 +707,7 @@ mod tests {
                 characters: 200,
                 date: "2024-02-01".to_string(),
                 activity_type: "Reading".to_string(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -713,6 +720,7 @@ mod tests {
                 characters: 300,
                 date: "2024-03-01".to_string(),
                 activity_type: "Reading".to_string(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -908,6 +916,84 @@ mod tests {
 
         let logs = db::get_logs(&conn).unwrap();
         assert_eq!(logs.len(), 0);
+
+        std::fs::remove_file(csv_path).ok();
+    }
+
+    #[test]
+    fn test_export_logs_csv_includes_notes_column() {
+        let conn = setup_test_db();
+        let media_id = db::add_media_with_id(&conn, &sample_media("Notes Export")).unwrap();
+
+        db::add_log(
+            &conn,
+            &ActivityLog {
+                id: None,
+                media_id,
+                duration_minutes: 30,
+                characters: 0,
+                date: "2024-07-01".to_string(),
+                activity_type: "Reading".to_string(),
+                notes: "exported note text".to_string(),
+            },
+        )
+        .unwrap();
+
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "notes_export_{}_{}.csv",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::SeqCst)
+        ));
+        let path_str = path.to_str().unwrap().to_string();
+
+        let count = export_logs_csv(&conn, &path_str, None, None).unwrap();
+        assert_eq!(count, 1);
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("Notes"), "Header should include 'Notes'");
+        assert!(
+            content.contains("exported note text"),
+            "Row should contain the note text"
+        );
+
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn test_import_csv_with_notes_column_imports_note() {
+        let mut conn = setup_test_db();
+        let csv_path = write_csv(
+            "Date,Log Name,Media Type,Duration,Language,Characters,Activity Type,Notes\n\
+             2024-08-01,Notes Media,Reading,45,Japanese,1000,Reading,My note here\n",
+        );
+
+        let count = import_csv(&mut conn, &csv_path).unwrap();
+        assert_eq!(count, 1);
+
+        let logs = db::get_logs(&conn).unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].notes, "My note here");
+
+        std::fs::remove_file(csv_path).ok();
+    }
+
+    #[test]
+    fn test_import_csv_without_notes_column_imports_with_empty_notes() {
+        // Old-format CSV without a Notes column should import cleanly with empty notes.
+        // Guards the #[serde(rename = "Notes", default)] on CsvRow.notes.
+        let mut conn = setup_test_db();
+        let csv_path = write_csv(
+            "Date,Log Name,Media Type,Duration,Language,Characters,Activity Type\n\
+             2024-09-01,Old Format Media,Reading,30,Japanese,500,Reading\n",
+        );
+
+        let count = import_csv(&mut conn, &csv_path).unwrap();
+        assert_eq!(count, 1);
+
+        let logs = db::get_logs(&conn).unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].notes, "");
 
         std::fs::remove_file(csv_path).ok();
     }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -12,7 +12,7 @@ use crate::models::{
     TimelineEventKind,
 };
 
-pub const CURRENT_SCHEMA_VERSION: i64 = 2;
+pub const CURRENT_SCHEMA_VERSION: i64 = 3;
 
 type MigrationFn = fn(&Connection) -> Result<()>;
 
@@ -22,11 +22,18 @@ struct Migration {
     apply: MigrationFn,
 }
 
-const VERSIONED_MIGRATIONS: &[Migration] = &[Migration {
-    from: 1,
-    to: 2,
-    apply: migrate_v1_to_v2_add_sync_foundation,
-}];
+const VERSIONED_MIGRATIONS: &[Migration] = &[
+    Migration {
+        from: 1,
+        to: 2,
+        apply: migrate_v1_to_v2_add_sync_foundation,
+    },
+    Migration {
+        from: 2,
+        to: 3,
+        apply: migrate_v2_to_v3_add_activity_notes,
+    },
+];
 
 const KECHIMOCHI_SYNC_NAMESPACE: &str = "0718e147-943f-4f0a-977d-5447bb2342f2";
 
@@ -51,6 +58,7 @@ const ACTIVITY_LOG_COLUMNS: &[&str] = &[
     "characters",
     "date",
     "activity_type",
+    "notes",
 ];
 
 const MILESTONE_COLUMNS: &[&str] = &[
@@ -620,6 +628,17 @@ fn migrate_v1_to_v2_add_sync_foundation(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn migrate_v2_to_v3_add_activity_notes(conn: &Connection) -> Result<()> {
+    let _ = add_column_if_missing(
+        conn,
+        "main",
+        "activity_logs",
+        "notes",
+        "TEXT NOT NULL DEFAULT ''",
+    )?;
+    Ok(())
+}
+
 fn migrate_to_shared(conn: &Connection) -> Result<()> {
     // Check if `main.media` exists
     if table_exists(conn, "main", "media")? {
@@ -761,7 +780,8 @@ fn create_activity_logs_table(conn: &Connection) -> Result<()> {
             duration_minutes INTEGER NOT NULL,
             characters INTEGER NOT NULL DEFAULT 0,
             date TEXT NOT NULL,
-            activity_type TEXT NOT NULL DEFAULT ''
+            activity_type TEXT NOT NULL DEFAULT '',
+            notes TEXT NOT NULL DEFAULT ''
         )",
         [],
     )?;
@@ -943,6 +963,7 @@ fn migrate_legacy_pre_release_to_current_schema(conn: &Connection) -> Result<()>
     migrate_to_character_tracking(conn)?;
     migrate_activity_type_to_logs(conn)?;
     migrate_settings_updated_at(conn)?;
+    migrate_v2_to_v3_add_activity_notes(conn)?;
     create_indexes(conn)?;
     Ok(())
 }
@@ -1274,8 +1295,8 @@ pub fn add_log(conn: &Connection, log: &ActivityLog) -> Result<i64> {
         )));
     }
     conn.execute(
-        "INSERT INTO main.activity_logs (media_id, duration_minutes, characters, date, activity_type) VALUES (?1, ?2, ?3, ?4, ?5)",
-        params![log.media_id, log.duration_minutes, log.characters, log.date, log.activity_type],
+        "INSERT INTO main.activity_logs (media_id, duration_minutes, characters, date, activity_type, notes) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![log.media_id, log.duration_minutes, log.characters, log.date, log.activity_type, log.notes],
     )?;
     Ok(conn.last_insert_rowid())
 }
@@ -1295,8 +1316,8 @@ pub fn update_log(conn: &Connection, log: &ActivityLog) -> Result<()> {
         )));
     }
     conn.execute(
-        "UPDATE main.activity_logs SET media_id = ?1, duration_minutes = ?2, characters = ?3, date = ?4, activity_type = ?5 WHERE id = ?6",
-        params![log.media_id, log.duration_minutes, log.characters, log.date, log.activity_type, log.id.unwrap()],
+        "UPDATE main.activity_logs SET media_id = ?1, duration_minutes = ?2, characters = ?3, date = ?4, activity_type = ?5, notes = ?6 WHERE id = ?7",
+        params![log.media_id, log.duration_minutes, log.characters, log.date, log.activity_type, log.notes, log.id.unwrap()],
     )?;
     Ok(())
 }
@@ -1308,8 +1329,8 @@ pub fn clear_activities(conn: &Connection) -> Result<()> {
 
 pub fn get_logs(conn: &Connection) -> Result<Vec<ActivitySummary>> {
     let mut stmt = conn.prepare(
-        "SELECT a.id, a.media_id, m.title, COALESCE(NULLIF(a.activity_type, ''), m.media_type) as activity_type, a.duration_minutes, a.characters, a.date, m.language 
-         FROM main.activity_logs a 
+        "SELECT a.id, a.media_id, m.title, COALESCE(NULLIF(a.activity_type, ''), m.media_type) as activity_type, a.duration_minutes, a.characters, a.date, m.language, a.notes
+         FROM main.activity_logs a
          JOIN shared.media m ON a.media_id = m.id
          ORDER BY a.date DESC, a.id DESC",
     )?;
@@ -1323,6 +1344,7 @@ pub fn get_logs(conn: &Connection) -> Result<Vec<ActivitySummary>> {
             characters: row.get(5)?,
             date: row.get(6)?,
             language: row.get(7)?,
+            notes: row.get(8)?,
         })
     })?;
 
@@ -1335,8 +1357,8 @@ pub fn get_logs(conn: &Connection) -> Result<Vec<ActivitySummary>> {
 
 pub fn get_logs_for_media(conn: &Connection, media_id: i64) -> Result<Vec<ActivitySummary>> {
     let mut stmt = conn.prepare(
-        "SELECT a.id, a.media_id, m.title, COALESCE(NULLIF(a.activity_type, ''), m.media_type) as activity_type, a.duration_minutes, a.characters, a.date, m.language 
-         FROM main.activity_logs a 
+        "SELECT a.id, a.media_id, m.title, COALESCE(NULLIF(a.activity_type, ''), m.media_type) as activity_type, a.duration_minutes, a.characters, a.date, m.language, a.notes
+         FROM main.activity_logs a
          JOIN shared.media m ON a.media_id = m.id
          WHERE a.media_id = ?1
          ORDER BY a.date DESC, a.id DESC",
@@ -1351,6 +1373,7 @@ pub fn get_logs_for_media(conn: &Connection, media_id: i64) -> Result<Vec<Activi
             characters: row.get(5)?,
             date: row.get(6)?,
             language: row.get(7)?,
+            notes: row.get(8)?,
         })
     })?;
 
@@ -2027,6 +2050,7 @@ mod tests {
             characters: 1200,
             date: date.to_string(),
             activity_type: activity_type.to_string(),
+            notes: String::new(),
         }
     }
 
@@ -2262,6 +2286,7 @@ mod tests {
             characters: 0,
             date: "2024-01-15".to_string(),
             activity_type: String::new(),
+            notes: String::new(),
         };
         add_log(&conn, &log).unwrap();
         add_milestone(
@@ -2307,6 +2332,7 @@ mod tests {
                 characters: 0,
                 date: "2024-01-01".to_string(),
                 activity_type: String::new(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -2329,6 +2355,7 @@ mod tests {
             characters: 100,
             date: "2024-03-01".to_string(),
             activity_type: String::new(),
+            notes: String::new(),
         };
         let log_id = add_log(&conn, &log).unwrap();
         assert!(log_id > 0);
@@ -2352,6 +2379,7 @@ mod tests {
             characters: 0,
             date: "2024-03-01".to_string(),
             activity_type: String::new(),
+            notes: String::new(),
         };
         let result = add_log(&conn, &log);
         assert!(result.is_err());
@@ -2377,6 +2405,7 @@ mod tests {
                 characters: 100,
                 date: "2024-06-01".to_string(),
                 activity_type: String::new(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -2389,6 +2418,7 @@ mod tests {
                 characters: 200,
                 date: "2024-06-01".to_string(),
                 activity_type: String::new(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -2403,6 +2433,7 @@ mod tests {
                 characters: 50,
                 date: "2024-06-02".to_string(),
                 activity_type: String::new(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -2432,6 +2463,7 @@ mod tests {
                 characters: 0,
                 date: "2024-03-01".to_string(),
                 activity_type: String::new(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -2444,6 +2476,7 @@ mod tests {
                 characters: 0,
                 date: "2024-03-02".to_string(),
                 activity_type: String::new(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -2800,6 +2833,7 @@ mod tests {
                 characters: 0,
                 date: "2024-01-01".to_string(),
                 activity_type: String::new(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -2835,6 +2869,7 @@ mod tests {
                 characters: 0,
                 date: "2024-03-01".to_string(),
                 activity_type: String::new(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -2858,6 +2893,7 @@ mod tests {
                 characters: 0,
                 date: "2024-03-02".to_string(),
                 activity_type: String::new(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -2881,6 +2917,7 @@ mod tests {
                 characters: 0,
                 date: "2024-01-01".to_string(),
                 activity_type: String::new(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -3430,6 +3467,7 @@ mod tests {
             characters: 0,
             date: "2024-01-01".to_string(),
             activity_type: String::new(),
+            notes: String::new(),
         };
         let id = add_log(&conn, &log).unwrap();
 
@@ -3440,6 +3478,7 @@ mod tests {
             characters: 100,
             date: "2024-01-02".to_string(),
             activity_type: "Watching".to_string(),
+            notes: String::new(),
         };
         update_log(&conn, &updated_log).unwrap();
 
@@ -3448,5 +3487,261 @@ mod tests {
         assert_eq!(logs[0].duration_minutes, 45);
         assert_eq!(logs[0].characters, 100);
         assert_eq!(logs[0].date, "2024-01-02");
+    }
+
+    #[test]
+    fn test_fresh_db_has_notes_column_and_is_at_schema_v3() {
+        let temp_dir = unique_temp_dir("notes_fresh_v3");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        let conn = init_db(temp_dir.clone(), None).unwrap();
+
+        assert_eq!(
+            get_bundle_schema_version(&conn).unwrap(),
+            CURRENT_SCHEMA_VERSION
+        );
+        assert_eq!(CURRENT_SCHEMA_VERSION, 3);
+        assert!(table_has_column(&conn, "main", "activity_logs", "notes").unwrap());
+        assert!(latest_schema_is_present(&conn).unwrap());
+        validate_latest_schema(&conn).unwrap();
+
+        std::fs::remove_dir_all(temp_dir).ok();
+    }
+
+    #[test]
+    fn test_v2_to_v3_migration_adds_notes_column() {
+        let temp_dir = unique_temp_dir("notes_v2_to_v3");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        let user_db = temp_dir.join("kechimochi_user.db");
+        let shared_db = temp_dir.join("kechimochi_shared_media.db");
+
+        // Set up a v2 database (no notes column, schema version 2)
+        {
+            let conn = Connection::open(&user_db).unwrap();
+            conn.execute_batch(
+                "PRAGMA user_version = 2;
+                 CREATE TABLE main.activity_logs (
+                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                     media_id INTEGER NOT NULL,
+                     duration_minutes INTEGER NOT NULL,
+                     characters INTEGER NOT NULL DEFAULT 0,
+                     date TEXT NOT NULL,
+                     activity_type TEXT NOT NULL DEFAULT ''
+                 );
+                 CREATE TABLE main.milestones (
+                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                     media_uid TEXT,
+                     media_title TEXT NOT NULL DEFAULT '',
+                     name TEXT NOT NULL DEFAULT '',
+                     duration INTEGER NOT NULL DEFAULT 0,
+                     characters INTEGER NOT NULL DEFAULT 0,
+                     date TEXT
+                 );
+                 CREATE TABLE main.settings (
+                     key TEXT PRIMARY KEY,
+                     value TEXT NOT NULL,
+                     updated_at TEXT NOT NULL DEFAULT ''
+                 );
+                 CREATE TABLE main.profile_picture (
+                     id INTEGER PRIMARY KEY CHECK (id = 1),
+                     mime_type TEXT NOT NULL,
+                     base64_data TEXT NOT NULL,
+                     byte_size INTEGER NOT NULL,
+                     width INTEGER NOT NULL,
+                     height INTEGER NOT NULL,
+                     updated_at TEXT NOT NULL
+                 );
+                 INSERT INTO main.activity_logs (media_id, duration_minutes, characters, date, activity_type)
+                     VALUES (1, 60, 0, '2024-01-01', 'Reading');",
+            )
+            .unwrap();
+        }
+        {
+            let conn = Connection::open(&shared_db).unwrap();
+            conn.execute_batch(
+                "PRAGMA user_version = 2;
+                 CREATE TABLE main.media (
+                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                     uid TEXT,
+                     title TEXT NOT NULL UNIQUE,
+                     media_type TEXT NOT NULL,
+                     status TEXT NOT NULL,
+                     language TEXT NOT NULL,
+                     description TEXT DEFAULT '',
+                     cover_image TEXT DEFAULT '',
+                     extra_data TEXT DEFAULT '{}',
+                     content_type TEXT DEFAULT 'Unknown',
+                     tracking_status TEXT DEFAULT 'Untracked',
+                     updated_at TEXT DEFAULT '',
+                     updated_by_device_id TEXT DEFAULT ''
+                 );
+                 INSERT INTO main.media (id, uid, title, media_type, status, language, description, cover_image, extra_data, content_type, tracking_status, updated_at, updated_by_device_id)
+                     VALUES (1, 'test-uid-1', 'Pre-existing Media', 'Reading', 'Active', 'Japanese', '', '', '{}', 'Novel', 'Ongoing', '', '');",
+            )
+            .unwrap();
+        }
+
+        let conn = init_db(temp_dir.clone(), None).unwrap();
+
+        assert_eq!(
+            get_bundle_schema_version(&conn).unwrap(),
+            CURRENT_SCHEMA_VERSION
+        );
+        assert!(table_has_column(&conn, "main", "activity_logs", "notes").unwrap());
+
+        // Pre-existing row should have empty notes
+        let logs = get_logs(&conn).unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].notes, "");
+        assert_eq!(logs[0].duration_minutes, 60);
+
+        std::fs::remove_dir_all(temp_dir).ok();
+    }
+
+    #[test]
+    fn test_no_op_startup_on_v3_db_stays_at_v3() {
+        let temp_dir = unique_temp_dir("notes_noop_v3");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        // First init creates the DB at v3
+        let conn1 = init_db(temp_dir.clone(), None).unwrap();
+        let media_id = add_media_with_id(&conn1, &sample_media("No-op Media")).unwrap();
+        add_log(
+            &conn1,
+            &ActivityLog {
+                id: None,
+                media_id,
+                duration_minutes: 20,
+                characters: 0,
+                date: "2024-05-01".to_string(),
+                activity_type: "Reading".to_string(),
+                notes: "persistent note".to_string(),
+            },
+        )
+        .unwrap();
+        drop(conn1);
+
+        // Second init should be a no-op
+        let conn2 = init_db(temp_dir.clone(), None).unwrap();
+        assert_eq!(get_bundle_schema_version(&conn2).unwrap(), 3);
+
+        let logs = get_logs(&conn2).unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].notes, "persistent note");
+
+        std::fs::remove_dir_all(temp_dir).ok();
+    }
+
+    #[test]
+    fn test_notes_are_saved_and_retrieved_via_add_update_log() {
+        let conn = setup_test_db();
+        let media_id = add_media_with_id(&conn, &sample_media("Notes CRUD")).unwrap();
+
+        // Add a log with notes
+        let log_id = add_log(
+            &conn,
+            &ActivityLog {
+                id: None,
+                media_id,
+                duration_minutes: 30,
+                characters: 0,
+                date: "2024-06-01".to_string(),
+                activity_type: "Reading".to_string(),
+                notes: "My first note".to_string(),
+            },
+        )
+        .unwrap();
+
+        let logs = get_logs(&conn).unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].notes, "My first note");
+
+        let logs_for_media = get_logs_for_media(&conn, media_id).unwrap();
+        assert_eq!(logs_for_media[0].notes, "My first note");
+
+        // Update to a different note
+        update_log(
+            &conn,
+            &ActivityLog {
+                id: Some(log_id),
+                media_id,
+                duration_minutes: 30,
+                characters: 0,
+                date: "2024-06-01".to_string(),
+                activity_type: "Reading".to_string(),
+                notes: "Updated note".to_string(),
+            },
+        )
+        .unwrap();
+
+        let updated_logs = get_logs(&conn).unwrap();
+        assert_eq!(updated_logs[0].notes, "Updated note");
+    }
+
+    #[test]
+    fn test_legacy_unversioned_upgrade_gains_notes_column() {
+        let temp_dir = unique_temp_dir("notes_legacy_upgrade");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        let user_db = temp_dir.join("kechimochi_user.db");
+        let shared_db = temp_dir.join("kechimochi_shared_media.db");
+
+        // Legacy DB layout: old-style main.media + activity_logs without notes
+        {
+            let legacy_conn = Connection::open(&user_db).unwrap();
+            legacy_conn
+                .execute(
+                    "CREATE TABLE media (
+                        id INTEGER PRIMARY KEY,
+                        title TEXT,
+                        media_type TEXT,
+                        status TEXT,
+                        language TEXT
+                    )",
+                    [],
+                )
+                .unwrap();
+            legacy_conn
+                .execute(
+                    "INSERT INTO media (id, title, media_type, status, language)
+                     VALUES (1, 'Legacy Notes Media', 'Reading', 'Ongoing', 'Japanese')",
+                    [],
+                )
+                .unwrap();
+            legacy_conn
+                .execute(
+                    "CREATE TABLE activity_logs (
+                        id INTEGER PRIMARY KEY,
+                        media_id INTEGER,
+                        duration_minutes INTEGER,
+                        date TEXT
+                    )",
+                    [],
+                )
+                .unwrap();
+            legacy_conn
+                .execute(
+                    "INSERT INTO activity_logs (id, media_id, duration_minutes, date)
+                     VALUES (1, 1, 90, '2024-03-01')",
+                    [],
+                )
+                .unwrap();
+        }
+        Connection::open(&shared_db).unwrap();
+
+        let conn = init_db(temp_dir.clone(), None).unwrap();
+        assert_eq!(
+            get_bundle_schema_version(&conn).unwrap(),
+            CURRENT_SCHEMA_VERSION
+        );
+        assert!(table_has_column(&conn, "main", "activity_logs", "notes").unwrap());
+
+        let logs = get_logs(&conn).unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].title, "Legacy Notes Media");
+        assert_eq!(logs[0].notes, "");
+
+        std::fs::remove_dir_all(temp_dir).ok();
     }
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -25,6 +25,8 @@ pub struct ActivityLog {
     pub date: String, // YYYY-MM-DD
     #[serde(default)]
     pub activity_type: String,
+    #[serde(default)]
+    pub notes: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -37,6 +39,7 @@ pub struct ActivitySummary {
     pub characters: i64,
     pub date: String,
     pub language: String,
+    pub notes: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src-tauri/src/sync_drive.rs
+++ b/src-tauri/src/sync_drive.rs
@@ -1118,6 +1118,7 @@ mod tests {
                     activity_type: "Playing".to_string(),
                     duration_minutes: 90,
                     characters: 0,
+                    notes: String::new(),
                 }],
                 milestones: vec![sync_snapshot::SnapshotMilestone {
                     name: "Finished Intro".to_string(),

--- a/src-tauri/src/sync_merge.rs
+++ b/src-tauri/src/sync_merge.rs
@@ -1144,6 +1144,7 @@ mod tests {
             activity_type: kind.to_string(),
             duration_minutes: minutes,
             characters: chars,
+            notes: String::new(),
         }
     }
 

--- a/src-tauri/src/sync_snapshot.rs
+++ b/src-tauri/src/sync_snapshot.rs
@@ -78,6 +78,8 @@ pub struct SnapshotActivity {
     pub activity_type: String,
     pub duration_minutes: i64,
     pub characters: i64,
+    #[serde(default)]
+    pub notes: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -220,6 +222,7 @@ where
                 activity_type: log.media_type,
                 duration_minutes: log.duration_minutes,
                 characters: log.characters,
+                notes: log.notes,
             });
         }
     }
@@ -443,6 +446,7 @@ fn apply_snapshot_inner(
                     characters: activity.characters,
                     date: activity.date.clone(),
                     activity_type: activity.activity_type.clone(),
+                    notes: activity.notes.clone(),
                 },
             )
             .map_err(|e| e.to_string())?;
@@ -709,6 +713,7 @@ mod tests {
                 characters: 200,
                 date: "2026-04-02".to_string(),
                 activity_type: "Reading".to_string(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -721,6 +726,7 @@ mod tests {
                 characters: 100,
                 date: "2026-04-01".to_string(),
                 activity_type: "Reading".to_string(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -827,6 +833,7 @@ mod tests {
                 characters: 0,
                 date: "2026-04-02".to_string(),
                 activity_type: "Reading".to_string(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -925,6 +932,7 @@ mod tests {
                 characters: 0,
                 date: "2026-04-01".to_string(),
                 activity_type: "Reading".to_string(),
+                notes: String::new(),
             },
         )
         .unwrap();
@@ -963,5 +971,114 @@ mod tests {
             rebuilt_media.updated_by_device_id,
             base_media.updated_by_device_id
         );
+    }
+
+    #[test]
+    fn test_snapshot_round_trips_activity_notes() {
+        let conn = setup_test_db();
+        let temp_dir = unique_temp_dir("snapshot_notes_roundtrip");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        let media_id = db::add_media_with_id(
+            &conn,
+            &sample_media("Notes Media", String::new(), "{}"),
+        )
+        .unwrap();
+
+        db::add_log(
+            &conn,
+            &ActivityLog {
+                id: None,
+                media_id,
+                duration_minutes: 40,
+                characters: 500,
+                date: "2026-05-01".to_string(),
+                activity_type: "Reading".to_string(),
+                notes: "My sync note".to_string(),
+            },
+        )
+        .unwrap();
+
+        let snapshot = build_snapshot(
+            &conn,
+            SnapshotBuildOptions {
+                snapshot_id: "snap_notes",
+                created_at: "2026-05-01T12:00:00Z",
+                created_by_device_id: "dev_notes",
+                profile_id: "prof_notes",
+                base_snapshot: None,
+                tombstones: &[],
+            },
+        )
+        .unwrap();
+
+        let media_entry = snapshot.library.values().next().unwrap();
+        assert_eq!(media_entry.activities.len(), 1);
+        assert_eq!(media_entry.activities[0].notes, "My sync note");
+
+        let json = snapshot_to_canonical_json(&snapshot).unwrap();
+        let parsed = parse_snapshot_json(&json).unwrap();
+        apply_snapshot(&conn, &parsed).unwrap();
+
+        let logs = db::get_logs(&conn).unwrap();
+        // After apply there will be duplicates since we applied on top of existing data,
+        // but all logs with non-empty notes should carry the note through.
+        let note_logs: Vec<_> = logs.iter().filter(|l| !l.notes.is_empty()).collect();
+        assert!(!note_logs.is_empty());
+        assert_eq!(note_logs[0].notes, "My sync note");
+
+        std::fs::remove_dir_all(temp_dir).ok();
+    }
+
+    #[test]
+    fn test_snapshot_activity_missing_notes_field_parses_as_empty() {
+        // A JSON snapshot without a "notes" field in activities should deserialize
+        // with notes defaulting to "".  This guards the #[serde(default)] on
+        // SnapshotActivity.notes.
+        let json_without_notes = r#"{
+            "sync_protocol_version": 1,
+            "db_schema_version": 2,
+            "snapshot_id": "old-snap",
+            "created_at": "2026-01-01T00:00:00Z",
+            "created_by_device_id": "old-device",
+            "profile": {
+                "profile_id": "prof-old",
+                "profile_name": "Old User",
+                "updated_at": "2026-01-01T00:00:00Z"
+            },
+            "library": {
+                "media-uid-1": {
+                    "uid": "media-uid-1",
+                    "title": "Old Media",
+                    "media_type": "Reading",
+                    "status": "Active",
+                    "language": "Japanese",
+                    "description": "",
+                    "content_type": "Novel",
+                    "tracking_status": "Ongoing",
+                    "extra_data": "{}",
+                    "cover_blob_sha256": null,
+                    "updated_at": "2026-01-01T00:00:00Z",
+                    "updated_by_device_id": "old-device",
+                    "activities": [
+                        {
+                            "date": "2026-01-01",
+                            "activity_type": "Reading",
+                            "duration_minutes": 30,
+                            "characters": 0
+                        }
+                    ],
+                    "milestones": []
+                }
+            },
+            "settings": {},
+            "profile_picture": null,
+            "tombstones": []
+        }"#;
+
+        let parsed = parse_snapshot_json(json_without_notes).unwrap();
+        let media_entry = parsed.library.values().next().unwrap();
+        assert_eq!(media_entry.activities.len(), 1);
+        assert_eq!(media_entry.activities[0].notes, "");
     }
 }

--- a/src/activity_modal.ts
+++ b/src/activity_modal.ts
@@ -139,6 +139,10 @@ export async function showLogActivityModal(prefillMediaTitle?: string, editLog?:
                         <label style="font-size: 0.85rem; color: var(--text-secondary);">Date</label>
                         <div id="activity-cal-container"></div>
                     </div>
+                    <div style="display: flex; flex-direction: column; gap: 0.5rem;">
+                        <label style="font-size: 0.85rem; color: var(--text-secondary);">Notes</label>
+                        <textarea id="activity-notes" rows="3" placeholder="Optional notes or reminders…" style="background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-color); padding: 0.5rem; border-radius: var(--radius-sm); width: 100%; box-sizing: border-box; height: 4.5rem; resize: none; overflow-y: auto; font: inherit;">${escapeHTML(editLog?.notes || '')}</textarea>
+                    </div>
                     <div style="display: flex; justify-content: flex-end; gap: 1rem; margin-top: 0.5rem;">
                         <button type="button" class="btn btn-ghost" id="activity-cancel">Cancel</button>
                         <button type="submit" class="btn btn-primary">${editLog ? 'Update Activity' : 'Log Activity'}</button>
@@ -306,6 +310,7 @@ export async function showLogActivityModal(prefillMediaTitle?: string, editLog?:
 
             try {
                 const activityType = overlay.querySelector<HTMLSelectElement>('#activity-type')!.value;
+                const notes = overlay.querySelector<HTMLTextAreaElement>('#activity-notes')!.value;
                 if (editLog) {
                     await updateLog({
                         id: editLog.id,
@@ -313,12 +318,13 @@ export async function showLogActivityModal(prefillMediaTitle?: string, editLog?:
                         duration_minutes: duration,
                         characters,
                         date: dateToSave,
-                        activity_type: activityType
+                        activity_type: activityType,
+                        notes
                     });
                 } else {
                     const mediaId = await resolveMediaId(mediaTitle);
                     if (mediaId === null) return;
-                    await addLog({ media_id: mediaId, duration_minutes: duration, characters, date: dateToSave, activity_type: activityType });
+                    await addLog({ media_id: mediaId, duration_minutes: duration, characters, date: dateToSave, activity_type: activityType, notes });
                 }
                 cleanup();
                 if (suggestionHideTimer) {

--- a/src/dashboard/Dashboard.ts
+++ b/src/dashboard/Dashboard.ts
@@ -479,7 +479,7 @@ export class Dashboard extends Component<DashboardState> {
                         <button class="btn btn-ghost btn-sm edit-log-btn" data-id="${log.id}" title="Edit Log" style="padding: 2px 6px;">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
                         </button>
-                        <button class="btn btn-ghost btn-sm delete-log-btn" data-id="${log.id}" title="Delete Log" style="padding: 2px 6px; color: var(--error);">
+                        <button class="btn btn-ghost btn-sm delete-log-btn" data-id="${log.id}" title="Delete Log" style="padding: 2px 6px; color: var(--accent-red);">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>
                         </button>
                     </div>

--- a/src/media/MediaLog.ts
+++ b/src/media/MediaLog.ts
@@ -1,5 +1,5 @@
 import { Component } from '../component';
-import { html, escapeHTML } from '../html';
+import { html, escapeHTML, rawHtml } from '../html';
 import { ActivitySummary, deleteLog } from '../api';
 import { formatLoggedDuration } from '../time';
 import { showLogActivityModal } from '../activity_modal';
@@ -28,18 +28,22 @@ export class MediaLog extends Component<MediaLogState> {
             const durationStr = log.duration_minutes > 0 ? formatLoggedDuration(log.duration_minutes, true) : '';
             const charStr = log.characters > 0 ? `${escapeHTML(log.characters.toLocaleString())} chars` : '';
             const separator = (durationStr && charStr) ? ' | ' : '';
- 
+            const notesStr = log.notes?.trim()
+                ? rawHtml(`<span style="color: var(--text-secondary); font-size: 0.8rem; white-space: pre-wrap;">${escapeHTML(log.notes)}</span>`)
+                : '';
+
             const entry = html`
                 <div class="media-detail-log-item" data-id="${log.id}" data-duration-minutes="${log.duration_minutes}" data-characters="${log.characters}" style="display: flex; justify-content: space-between; align-items: center; padding: 0.5rem; border-bottom: 1px solid var(--border-color); font-size: 0.9rem;">
                     <div style="display: flex; flex-direction: column; gap: 0.2rem;">
                         <span><span style="color: var(--text-secondary);">Activity:</span> ${durationStr}${separator}${charStr}</span>
                         <span style="color: var(--text-secondary); font-size: 0.8rem;">${log.date}</span>
+                        ${notesStr}
                     </div>
                     <div style="display: flex; gap: 0.5rem;">
                         <button class="btn btn-ghost btn-sm edit-log-btn" title="Edit Log" style="padding: 2px 6px;">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
                         </button>
-                        <button class="btn btn-ghost btn-sm delete-log-btn" title="Delete Log" style="padding: 2px 6px; color: var(--error);">
+                        <button class="btn btn-ghost btn-sm delete-log-btn" title="Delete Log" style="padding: 2px 6px; color: var(--accent-red);">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>
                         </button>
                     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1419,7 +1419,6 @@ input:focus, select:focus {
   padding: 0.2rem;
   margin: -0.2rem;
 }
-<
 #media-title-block{
   margin: 0.2rem;
   padding: 0.1rem;
@@ -2792,6 +2791,8 @@ input:focus, select:focus {
     padding: 0.65rem;
     border: 1px solid var(--border-color);
     border-radius: var(--radius-md);
+    /* --highlight-cover is injected at runtime per-card by ActivityTotals.ts (inline style); the var() below has a fallback. */
+    /*noinspection CssUnresolvedCustomProperty*/
     background:
         linear-gradient(90deg, color-mix(in srgb, var(--bg-dark) 92%, transparent), color-mix(in srgb, var(--bg-dark) 74%, transparent)),
         var(--highlight-cover, linear-gradient(135deg, var(--bg-dark), var(--bg-card-hover)));
@@ -3390,7 +3391,7 @@ input:checked + .slider:before {
 
   .mobile-top-bar {
     display: flex;
-    padding: 0.2rem 0rem;
+    padding: 0.2rem 0;
     gap:0.5rem;
     z-index: 84;
     height: calc(env(safe-area-inset-top) + 2rem);

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export interface ActivityLog {
     characters: number;
     date: string;
     activity_type?: string;
+    notes?: string;
 }
 
 export interface ActivitySummary {
@@ -51,6 +52,7 @@ export interface ActivitySummary {
     characters: number;
     date: string;
     language: string;
+    notes: string;
 }
 
 export interface DailyHeatmap {

--- a/tests/modals/activity.test.ts
+++ b/tests/modals/activity.test.ts
@@ -102,7 +102,8 @@ describe('modals/activity.ts', () => {
                 duration_minutes: 45,
                 characters: 0,
                 date: expect.any(String),
-                activity_type: 'Reading'
+                activity_type: 'Reading',
+                notes: ''
             });
         });
 
@@ -295,7 +296,8 @@ describe('modals/activity.ts', () => {
                 duration_minutes: 30,
                 characters: 100,
                 date: '2024-03-01',
-                language: 'Japanese'
+                language: 'Japanese',
+                notes: ''
             };
             
             vi.mocked(api.getAllMedia).mockResolvedValue([{ 
@@ -342,7 +344,8 @@ describe('modals/activity.ts', () => {
                 duration_minutes: 0,
                 characters: 100,
                 date: '2024-03-01',
-                language: 'Japanese'
+                language: 'Japanese',
+                notes: ''
             };
             vi.mocked(api.getAllMedia).mockResolvedValue([]);
 
@@ -361,7 +364,8 @@ describe('modals/activity.ts', () => {
                 duration_minutes: 0,
                 characters: 250,
                 date: '2024-03-01',
-                activity_type: 'Listening'
+                activity_type: 'Listening',
+                notes: ''
             });
         });
 
@@ -449,7 +453,7 @@ describe('modals/activity.ts', () => {
             titleInput.value = 'Blue Lock';
             titleInput.dispatchEvent(new Event('input'));
             expect(suggestions.style.display).toBe('block');
-            titleKeydownListeners.at(-1)?.({ key: 'Escape' } as KeyboardEvent);
+            titleKeydownListeners[titleKeydownListeners.length - 1]?.({ key: 'Escape' } as KeyboardEvent);
             expect(suggestions.style.display).toBe('none');
 
             titleInput.dispatchEvent(new Event('blur'));


### PR DESCRIPTION
Closes #25 

Adds a "notes" field to the DB scheme on media entries, and all the song and dance that goes along with that, together with a bump to the DB schema and adjusting relevant tests. The notes are also exported / imported correctly (verified through tests), and DB schema mismatches continue working as usual so no weird file corruption hijinks happens.

As for the front end, the "notes" field is a little multiline text area when logging / editing an activity. Horizontal text overflow just enters the next line, vertical text overflow just makes the textarea scrollable while the internal document grows (i.e., visually, the textarea never changes size).

<img width="471" height="733" alt="image" src="https://github.com/user-attachments/assets/b23a00da-c55c-412a-8b07-c6c77eb4ee6b" />

Right now, the notes are only displayed in the "Recent Activity" widget when looking at some media thing in the library, nowhere else. Seemed the most reasonable place to display it. One could argue whether media entries with a note should be shown in the timeline view or something, but I assumed there are some users that would add notes to every single media entry and it'd clutter up the timeline. Another option would be in the Dashboard in the "Recent Activity" widget, but that also seemed like a bad fit as this is supposed to be a more concise thing.

<img width="1272" height="1195" alt="image" src="https://github.com/user-attachments/assets/ade51fa4-8389-4e2b-b15f-cbb283251584" />

Finally, some small code style etc. fixes:

- `MediaLog.ts` and `Dashboard.ts` used a custom property, `var(--error)`, which isn't actually defined anywhere. Replaced with `var(--accent-red)` which is the actual property, probably just LLM hallucination.
- styles.css had a stray `<` that was removed and a `0rem` entry where the unit was unnecessary and hence removed.
- activity.test.ts had an `.at(-1)` call that is apparently bad form in TS, so that was refactored to use `[titleKeydownListeners.length - 1]`
- `styles.css` marked an error for an unresolved custom property, `var(--highlight-cover)`, which is injected at runtime and hence not actually an error. Marked as noinspection so the IDE ignores this, but maybe this should be refactored in the future to just be clean.