### PR TITLE
Bug: Window size too large by default (closes #202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog, with one section per released version.
 
 ## [Unreleased]
 
+### Fixed
+- Default window no longer opens larger than the screen / under the taskbar, which could hide the update dialog's close button (#202).
+
+### Added
+- The desktop app now remembers its window size, position, and maximized state between launches.
+
 ## [0.2.10] - 2026-06-10
 
 ### Added

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -324,6 +324,7 @@ export const config: WebdriverIO.Config = {
     caps['tauri:options'].envs = {
         ...caps['tauri:options'].envs,
         KECHIMOCHI_DATA_DIR: testDir,
+        KECHIMOCHI_DISABLE_WINDOW_MANAGEMENT: '1',
         ...syncEnv,
     };
 
@@ -367,6 +368,7 @@ export const config: WebdriverIO.Config = {
         env: {
           ...process.env,
           KECHIMOCHI_DATA_DIR: testDir,
+          KECHIMOCHI_DISABLE_WINDOW_MANAGEMENT: '1',
           ...syncEnv,
           RUST_LOG: 'debug',
           TAURI_DEBUG: '1'
@@ -413,8 +415,7 @@ export const config: WebdriverIO.Config = {
       const stageDir = process.env.SPEC_STAGE_DIR;
       if (stageDir) {
         const logFile = path.join(stageDir, 'tauri-driver.log');
-        const finalCode = tauriDriverExitCode;
-        try { appendFileSync(logFile, `\n[e2e] Session Complete with exit code: ${finalCode}\n`); } catch { /* ignore transient fs errors */ }
+        try { appendFileSync(logFile, `\n[e2e] Session Complete with exit code: ${tauriDriverExitCode}\n`); } catch { /* ignore transient fs errors */ }
       }
     }
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2195,6 +2195,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-opener",
+ "tauri-plugin-window-state",
  "tempfile",
  "tokio",
  "tower-http 0.5.2",
@@ -4612,6 +4613,21 @@ dependencies = [
  "url",
  "windows",
  "zbus 5.14.0",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-fs = "2.4.5"
+tauri-plugin-window-state = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.38.0", features = ["bundled"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",
     "core:window:allow-start-dragging",
+    "window-state:default",
     "all-app-commands"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,29 @@ const SYNC_PROGRESS_EVENT: &str = "sync-progress";
 const SYNC_TEST_AUTO_OPEN_ENV: &str = "KECHIMOCHI_SYNC_TEST_AUTO_OPEN";
 const SKIP_LEGACY_LOCAL_PROFILE_MIGRATION_ENV: &str =
     "KECHIMOCHI_E2E_SKIP_LEGACY_LOCAL_PROFILE_MIGRATION";
+const DISABLE_WINDOW_MANAGEMENT_ENV: &str = "KECHIMOCHI_DISABLE_WINDOW_MANAGEMENT";
+
+#[cfg(desktop)]
+fn window_management_enabled() -> bool {
+    std::env::var(DISABLE_WINDOW_MANAGEMENT_ENV).is_err()
+}
+
+/// Clamps a window's outer size so it fits within the monitor work area minus a
+/// margin. Only ever shrinks the window — a window that already fits is returned
+/// unchanged — and each dimension is clamped independently. Returns the
+/// `(width, height)` to apply.
+#[cfg(desktop)]
+fn clamp_size_to_work_area(
+    outer_width: u32,
+    outer_height: u32,
+    work_width: u32,
+    work_height: u32,
+    margin: u32,
+) -> (u32, u32) {
+    let max_width = work_width.saturating_sub(margin);
+    let max_height = work_height.saturating_sub(margin);
+    (outer_width.min(max_width), outer_height.min(max_height))
+}
 
 type SyncTokenStore = Box<dyn sync_auth::SecureTokenStore>;
 type SyncDbConn = Arc<Mutex<Connection>>;
@@ -1386,11 +1409,18 @@ pub fn get_username_logic() -> String {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let mut builder = tauri::Builder::default()
         .plugin(init_google_auth_mobile_plugin())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
-        .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_opener::init());
+
+    #[cfg(desktop)]
+    if window_management_enabled() {
+        builder = builder.plugin(tauri_plugin_window_state::Builder::default().build());
+    }
+
+    builder
         .setup(|app| {
             let app_dir = db::get_data_dir(app.handle());
             let user_db_path = app_dir.join("kechimochi_user.db");
@@ -1446,6 +1476,38 @@ pub fn run() {
                         }
                     }
                 });
+            }
+            #[cfg(desktop)]
+            if window_management_enabled() {
+                // Only clamp and center on first launch (no saved window state yet).
+                // Once the plugin has written its state file, it owns size/position restore.
+                let state_file = app
+                    .path()
+                    .app_config_dir()
+                    .map(|directory| directory.join(tauri_plugin_window_state::DEFAULT_FILENAME));
+                let is_first_launch = state_file.map_or(true, |path| !path.exists());
+                if is_first_launch {
+                    if let Some(window) = app.get_webview_window("main") {
+                        if let Ok(Some(monitor)) = window.current_monitor() {
+                            let work = monitor.work_area(); // tauri 2.10 — Rect of usable area (taskbar excluded)
+                            let margin = 32_u32; // breathing room
+                            if let Ok(outer) = window.outer_size() {
+                                let (new_w, new_h) = clamp_size_to_work_area(
+                                    outer.width,
+                                    outer.height,
+                                    work.size.width,
+                                    work.size.height,
+                                    margin,
+                                );
+                                if new_w != outer.width || new_h != outer.height {
+                                    let _ =
+                                        window.set_size(tauri::PhysicalSize::new(new_w, new_h));
+                                }
+                            }
+                            let _ = window.center();
+                        }
+                    }
+                }
             }
             Ok(())
         })
@@ -1526,4 +1588,41 @@ fn init_google_auth_mobile_plugin() -> tauri::plugin::TauriPlugin<tauri::Wry> {
             Ok(())
         })
         .build()
+}
+
+#[cfg(all(test, desktop))]
+mod window_clamp_tests {
+    use super::clamp_size_to_work_area;
+
+    #[test]
+    fn shrinks_a_window_larger_than_the_work_area() {
+        // 1280x1200 window on a 1080p work area (taskbar excluded), 32px margin.
+        assert_eq!(
+            clamp_size_to_work_area(1280, 1200, 1280, 1040, 32),
+            (1248, 1008)
+        );
+    }
+
+    #[test]
+    fn leaves_a_window_that_already_fits_unchanged() {
+        // 1280x860 default on a 1440p work area has room to spare.
+        assert_eq!(
+            clamp_size_to_work_area(1280, 860, 2560, 1440, 32),
+            (1280, 860)
+        );
+    }
+
+    #[test]
+    fn clamps_only_the_overflowing_dimension() {
+        // Width fits, height overflows.
+        assert_eq!(
+            clamp_size_to_work_area(1280, 1200, 2560, 1040, 32),
+            (1280, 1008)
+        );
+    }
+
+    #[test]
+    fn does_not_underflow_when_the_work_area_is_smaller_than_the_margin() {
+        assert_eq!(clamp_size_to_work_area(800, 600, 16, 16, 32), (0, 0));
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "label": "main",
         "title": "ケチモチ",
         "width": 1280,
-        "height": 1200,
+        "height": 860,
+        "center": true,
         "decorations": false,
         "transparent": true
       }


### PR DESCRIPTION
Closes #202 

There's parameters for the default window size in tauri.conf.json which were set to 1280x1200. This is now 1280x860 as a failsafe of sorts. It also centers the window.

Next, *only* on the first program start, we clamp the program window down to the workable monitor area (minus taskbar and such) if necessary, like some tiny monitor.

And finally, as a bonus, this introduces `tauri-plugin-window-state`. It remembers window size, location, and maximization state from the last session and restores this when the next session starts.

For the E2E suite, Android mode, and Web mode, all of this is (of course) overridden - we only care about the Desktop mode here.

I personally develop on a Xubuntu VM, and it seems Tauri itself has some open bugs for window management under XFCE / X11, which affects me in my dev WM. Specifically:
- On first start, the window centering is a little misaligned
- A window being maximized can sometimes store the "pre-maximized window size" parameter as the size of the maximized window. I.e., maximizing window, closing program, and starting it again will restore the window maximized - but then moving it has it in "unmaximized, but the size of maximized" state. It's somewhat annoying, but that's about it. Further, this behaviour *should* be XFCE / X11 specific and hopefully fixed by Tauri eventually.