### PR TITLE
Bug: Cover image performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on Keep a Changelog, with one section per released version.
  - Interrupted backups automatically restore the original data
  - Several stability and security vulnerability fixes
  - The reading time estimate in the media detail view sometimes never appeared
+ - Cover images load much faster in the desktop and Android apps, and no longer stall the interface when many of them load at once
 
 ## [0.3.1] - 2026-07-24
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -991,8 +991,11 @@ fn upload_cover_image(
 }
 
 #[tauri::command]
-fn read_file_bytes(app_handle: tauri::AppHandle, path: String) -> Result<Vec<u8>, String> {
-    app_file_io::read_input_bytes(&app_handle, &path)
+fn read_file_bytes(
+    app_handle: tauri::AppHandle,
+    path: String,
+) -> Result<tauri::ipc::Response, String> {
+    app_file_io::read_input_bytes(&app_handle, &path).map(tauri::ipc::Response::new)
 }
 
 #[tauri::command]

--- a/src/api.ts
+++ b/src/api.ts
@@ -241,8 +241,8 @@ export function uploadCoverImage(mediaId: number, path: string): Promise<string>
   return desktopInvoke<string>('upload_cover_image', { mediaId, path });
 }
 
-export function readFileBytes(path: string): Promise<number[]> {
-  return desktopInvoke<number[]>('read_file_bytes', { path });
+export function readFileBytes(path: string): Promise<ArrayBuffer> {
+  return desktopInvoke<ArrayBuffer>('read_file_bytes', { path });
 }
 
 export function exportFullBackup(localStorageData: string, version: string): Promise<boolean> {

--- a/src/media/cover_loader.ts
+++ b/src/media/cover_loader.ts
@@ -158,10 +158,10 @@ export class MediaCoverLoader {
         }
 
         const bytes = await readFileBytes(coverRef);
-        const blob = new Blob([new Uint8Array(bytes)]);
+        const blob = new Blob([bytes]);
         return {
             src: URL.createObjectURL(blob),
-            byteSize: bytes.length,
+            byteSize: bytes.byteLength,
         };
     }
 

--- a/src/services/desktop.ts
+++ b/src/services/desktop.ts
@@ -313,8 +313,8 @@ export class DesktopServices implements AppServices {
     async loadCoverImage(coverRef: string): Promise<string | null> {
         if (!coverRef || coverRef.trim() === '') return null;
         try {
-            const bytes = await invoke<number[]>('read_file_bytes', { path: coverRef });
-            const blob = new Blob([new Uint8Array(bytes)]);
+            const bytes = await invoke<ArrayBuffer>('read_file_bytes', { path: coverRef });
+            const blob = new Blob([bytes]);
             return URL.createObjectURL(blob);
         } catch {
             return null;

--- a/tests/components/media/MediaDetail.test.ts
+++ b/tests/components/media/MediaDetail.test.ts
@@ -114,7 +114,7 @@ describe('MediaDetail', () => {
 
     it('should render media details correctly', async () => {
         vi.mocked(api.getMilestones).mockResolvedValue([]);
-        vi.mocked(api.readFileBytes).mockResolvedValue([1, 2, 3]);
+        vi.mocked(api.readFileBytes).mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
 
         const component = new MediaDetailTestHarness(container, { ...mockMedia } as unknown as Media, [], [mockMedia as unknown as Media], 0, mockCallbacks);
         component.triggerMount();
@@ -326,7 +326,7 @@ describe('MediaDetail', () => {
 
     it('should use cached cover images without scheduling a second detail load', async () => {
         vi.mocked(api.getMilestones).mockResolvedValue([]);
-        vi.mocked(api.readFileBytes).mockResolvedValue([1, 2, 3]);
+        vi.mocked(api.readFileBytes).mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
 
         await MediaCoverLoader.load('/path/to/img.jpg');
         vi.clearAllMocks();
@@ -514,7 +514,7 @@ describe('MediaDetail', () => {
 
     it('should preserve a loaded detail cover in the shared cache on destroy', async () => {
         vi.mocked(api.getMilestones).mockResolvedValue([]);
-        vi.mocked(api.readFileBytes).mockResolvedValue([1, 2, 3]);
+        vi.mocked(api.readFileBytes).mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
 
         const component = new MediaDetailTestHarness(container, { ...mockMedia } as unknown as Media, [], [mockMedia as unknown as Media], 0, mockCallbacks);
         component.triggerMount();

--- a/tests/components/media/MediaItem.test.ts
+++ b/tests/components/media/MediaItem.test.ts
@@ -45,7 +45,7 @@ describe('MediaItem', () => {
     });
 
     it('should load image when intersecting', async () => {
-        vi.mocked(api.readFileBytes).mockResolvedValue([1, 2, 3]);
+        vi.mocked(api.readFileBytes).mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
         // Mock URL.createObjectURL
         globalThis.URL.createObjectURL = vi.fn(() => 'blob:abc');
 
@@ -79,7 +79,7 @@ describe('MediaItem', () => {
     });
 
     it('should load eager covers without waiting for an intersection', async () => {
-        vi.mocked(api.readFileBytes).mockResolvedValue([1, 2, 3]);
+        vi.mocked(api.readFileBytes).mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
         globalThis.URL.createObjectURL = vi.fn(() => 'blob:eager');
 
         const media = { title: 'Eager', cover_image: '/path/to/eager.jpg', status: 'Active' };
@@ -93,7 +93,7 @@ describe('MediaItem', () => {
     });
 
     it('should reuse cached cover images without reading bytes again', async () => {
-        vi.mocked(api.readFileBytes).mockResolvedValue([1, 2, 3]);
+        vi.mocked(api.readFileBytes).mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
         globalThis.URL.createObjectURL = vi.fn(() => 'blob:cached');
 
         const media = { title: 'Cached', cover_image: '/path/to/cached.jpg', status: 'Active' };
@@ -109,7 +109,7 @@ describe('MediaItem', () => {
     });
 
     it('reconciles a retained cover after its desktop object URL is invalidated', async () => {
-        vi.mocked(api.readFileBytes).mockResolvedValue([1, 2, 3]);
+        vi.mocked(api.readFileBytes).mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
         globalThis.URL.createObjectURL = vi.fn()
             .mockReturnValueOnce('blob:retained-cover-1')
             .mockReturnValueOnce('blob:retained-cover-2');
@@ -151,7 +151,7 @@ describe('MediaItem', () => {
     });
 
     it('should not commit a cover that resolves after the item is destroyed', async () => {
-        let resolveBytes: (bytes: number[]) => void = (_bytes: number[]) => undefined;
+        let resolveBytes: (bytes: ArrayBuffer) => void = (_bytes: ArrayBuffer) => undefined;
         vi.mocked(api.readFileBytes).mockReturnValue(new Promise(resolve => {
             resolveBytes = resolve;
         }));
@@ -165,7 +165,7 @@ describe('MediaItem', () => {
         await vi.waitFor(() => expect(api.readFileBytes).toHaveBeenCalledWith('/path/to/late.jpg'));
 
         component.destroy();
-        resolveBytes([1, 2, 3]);
+        resolveBytes(new Uint8Array([1, 2, 3]).buffer);
         await vi.waitFor(() => expect(createObjectUrl).toHaveBeenCalledOnce());
         await new Promise(resolve => setTimeout(resolve, 0));
 

--- a/tests/components/media/MediaListItem.test.ts
+++ b/tests/components/media/MediaListItem.test.ts
@@ -77,7 +77,7 @@ describe('MediaListItem', () => {
     });
 
     it('loads cover images through the shared loader path', async () => {
-        vi.mocked(api.readFileBytes).mockResolvedValue([1, 2, 3]);
+        vi.mocked(api.readFileBytes).mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
         globalThis.URL.createObjectURL = vi.fn(() => 'blob:list-item');
 
         const component = new MediaListItemTestHarness(
@@ -107,7 +107,7 @@ describe('MediaListItem', () => {
     });
 
     it('replaces the placeholder with the loaded image rather than keeping both in the cover shell', async () => {
-        vi.mocked(api.readFileBytes).mockResolvedValue([1, 2, 3]);
+        vi.mocked(api.readFileBytes).mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
         globalThis.URL.createObjectURL = vi.fn(() => 'blob:list-item');
 
         const component = new MediaListItemTestHarness(

--- a/tests/components/media/cover_loader.test.ts
+++ b/tests/components/media/cover_loader.test.ts
@@ -32,7 +32,7 @@ describe('MediaCoverLoader', () => {
     });
 
     it('loads and caches desktop covers', async () => {
-        vi.mocked(api.readFileBytes).mockResolvedValue([1, 2, 3]);
+        vi.mocked(api.readFileBytes).mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
         globalThis.URL.createObjectURL = vi.fn(() => 'blob:desktop-cover');
 
         await expect(MediaCoverLoader.load('/app/covers/cover.png')).resolves.toBe('blob:desktop-cover');
@@ -42,7 +42,7 @@ describe('MediaCoverLoader', () => {
     });
 
     it('can load desktop covers without writing through to the shared cache', async () => {
-        vi.mocked(api.readFileBytes).mockResolvedValue([1, 2, 3]);
+        vi.mocked(api.readFileBytes).mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
         globalThis.URL.createObjectURL = vi.fn()
             .mockReturnValueOnce('blob:detail-cover-1')
             .mockReturnValueOnce('blob:detail-cover-2');
@@ -55,7 +55,7 @@ describe('MediaCoverLoader', () => {
     });
 
     it('revokes cached object URLs when clearing the shared cache', async () => {
-        vi.mocked(api.readFileBytes).mockResolvedValue([1, 2, 3]);
+        vi.mocked(api.readFileBytes).mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
         globalThis.URL.createObjectURL = vi.fn(() => 'blob:desktop-cover');
         globalThis.URL.revokeObjectURL = vi.fn();
 
@@ -111,7 +111,7 @@ describe('MediaCoverLoader', () => {
     });
 
     it('drops and revokes an old-generation result after data isolation is reset', async () => {
-        let resolveBytes!: (value: number[]) => void;
+        let resolveBytes!: (value: ArrayBuffer) => void;
         vi.mocked(api.readFileBytes).mockImplementation(() => new Promise(resolve => {
             resolveBytes = resolve;
         }));
@@ -120,7 +120,7 @@ describe('MediaCoverLoader', () => {
 
         const pending = MediaCoverLoader.load('/old/data/cover.png');
         MediaCoverLoader.clear();
-        resolveBytes([1, 2, 3]);
+        resolveBytes(new Uint8Array([1, 2, 3]).buffer);
 
         await expect(pending).resolves.toBeNull();
         expect(globalThis.URL.revokeObjectURL).toHaveBeenCalledWith('blob:old-generation');


### PR DESCRIPTION
Related to PR #262 (which itself is for issue #79)

Tried to track the performance for the timeline down. There's still a few parts to squeeze, but nothing that should explain a *major* performance gain. I wasn't able to replicate the issue with my faux DB, but that one didn't have images.

After creating a new faux DB *with cover images*, I was able to confirm some performance issues in the timeline view related to the way images are loaded, which technically belongs into its own PR as an unrelated bugfix. I program on a shitty xubuntu VM so performance is ass anyway, but at least in that environment, it was a roughly 10x speedup on heavy image loads (from "horribly unusable" to "actually normal").

There is no guarantee that this is also the cause of the issues with the timeline zoom performance, but it *could* be the reason.