### PR TITLE
Code health: CSS color tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on Keep a Changelog, with one section per released version.
  - Interrupted backups automatically restore the original data
  - Several stability and security vulnerability fixes
  - The reading time estimate in the media detail view sometimes never appeared
+ - The startup error and database recovery screens now show their intended background gradient
+ - The Jiten.moe search dialog title was invisible on the light themes
 
 ## [0.3.1] - 2026-07-24
 

--- a/e2e/specs/desktop/data-management.spec.ts
+++ b/e2e/specs/desktop/data-management.spec.ts
@@ -7,6 +7,7 @@ import { navigateTo, verifyActiveView } from '../../helpers/navigation.js';
 import { dismissAlert } from '../../helpers/common.js';
 import { clickMediaItem } from '../../helpers/library.js';
 import { logActivityFromDetail } from '../../helpers/media-detail.js';
+import { setCheckbox } from '../../helpers/form-controls.js';
 
 const ACTIVITY_CSV_HEADERS = [
   'Date',
@@ -160,9 +161,7 @@ describe('CUJ: Data Management (CSV Export)', () => {
         await browser.execute((el: unknown) => (el as HTMLElement).click(), exportBtn);
     }
 
-    const radioRange = await $('input[name="export-mode"][value="range"]');
-    await radioRange.waitForDisplayed();
-    await radioRange.click();
+    await setCheckbox('input[name="export-mode"][value="range"]', true);
 
     const confirmBtn = await $('#export-confirm');
     await confirmBtn.click();

--- a/src/activity_modal.ts
+++ b/src/activity_modal.ts
@@ -37,7 +37,7 @@ export async function showExportCsvModal(): Promise<{mode: 'all' | 'range', star
                     <label style="display: flex; gap: 0.5rem; align-items: center; cursor: pointer;"><input type="radio" name="export-mode" value="all" checked /> All History</label>
                     <label style="display: flex; gap: 0.5rem; align-items: center; cursor: pointer; margin-top: 0.5rem;"><input type="radio" name="export-mode" value="range" /> Date Range</label>
                 </div>
-                <div id="export-range-inputs" style="display: none; align-items: flex-start; gap: 1.5rem; margin-top: 1rem; padding: 1rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: #1a151f;">
+                <div id="export-range-inputs" style="display: none; align-items: flex-start; gap: 1.5rem; margin-top: 1rem; padding: 1rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: var(--bg-elevated);">
                     <div style="display: flex; flex-direction: column; gap: 0.5rem; align-items: center;"><label style="font-size: 0.85rem; color: var(--text-secondary);">Start Date</label><div id="cal-start-container"></div></div>
                     <div style="display: flex; flex-direction: column; gap: 0.5rem; align-items: center;"><label style="font-size: 0.85rem; color: var(--text-secondary);">End Date</label><div id="cal-end-container"></div></div>
                 </div>
@@ -212,7 +212,7 @@ export async function showLogActivityModal(prefillMediaId?: number, editLog?: Ac
                         <label style="font-size: 0.85rem; color: var(--text-secondary);">Media Title</label>
                         <input type="text" id="activity-media" role="combobox" aria-autocomplete="list" aria-controls="activity-media-suggestions" aria-expanded="false" autocomplete="off" style="background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-color); padding: 0.5rem; border-radius: var(--radius-sm);" value="${escapedTitle}" ${editLog ? 'disabled' : ''} required oninvalid="this.setCustomValidity('Media Title is required')" oninput="this.setCustomValidity('')" />
                         <div id="activity-media-variant" style="display: none; color: var(--text-secondary); font-size: 0.78rem;"></div>
-                        <div id="activity-media-suggestions" role="listbox" style="display: none; margin-top: 0.35rem; max-height: 11rem; overflow-y: auto; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: color-mix(in srgb, var(--bg-card) 94%, black 6%); box-shadow: 0 14px 34px rgba(0, 0, 0, 0.22); position: absolute; top: 100%; left: 0; right: 0;"></div>
+                        <div id="activity-media-suggestions" role="listbox" style="display: none; margin-top: 0.35rem; max-height: 11rem; overflow-y: auto; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: color-mix(in srgb, var(--bg-card) 94%, black 6%); box-shadow: 0 14px 34px color-mix(in srgb, var(--tint-dark) 22%, transparent); position: absolute; top: 100%; left: 0; right: 0;"></div>
                     </div>
                     <div style="display: flex; gap: 0.5rem; align-items: center;">
                         <div style="flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 0.5rem;">
@@ -383,7 +383,7 @@ export async function showLogActivityModal(prefillMediaId?: number, editLog?: Ac
                 suggestionList.querySelectorAll<HTMLElement>('.activity-media-suggestion').forEach((option, optionIndex) => {
                     const isHighlighted = optionIndex === highlightedSuggestionIndex;
                     option.setAttribute('aria-selected', String(isHighlighted));
-                    option.style.background = isHighlighted ? 'rgba(255,255,255,0.08)' : 'transparent';
+                    option.style.background = isHighlighted ? 'color-mix(in srgb, var(--tint-light) 8%, transparent)' : 'transparent';
                     if (isHighlighted) option.scrollIntoView?.({ block: 'nearest' });
                 });
                 titleInput.setAttribute('aria-activedescendant', `activity-media-suggestion-${highlightedSuggestionIndex}`);

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -17,7 +17,7 @@ export function buildCalendar(container: HTMLElement, initialDate: string, onSel
                     <button type="button" class="btn btn-ghost cal-nav-next" style="padding: 0 0.5rem; height: 24px; min-width: 24px; font-size: 0.8rem;">&gt;</button>
                 </div>
                 <div style="display: grid; grid-template-columns: repeat(7, 1fr); text-align: center; font-size: 0.75rem; color: var(--text-secondary); margin-bottom: 0.5rem;">
-                    <div style="color: #ff4757;">Su</div><div>Mo</div><div>Tu</div><div>We</div><div>Th</div><div>Fr</div><div style="color: #1e90ff;">Sa</div>
+                    <div style="color: var(--calendar-sunday);">Su</div><div>Mo</div><div>Tu</div><div>We</div><div>Th</div><div>Fr</div><div style="color: var(--calendar-saturday);">Sa</div>
                 </div>
                 <div style="display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px;">
         `;
@@ -27,7 +27,7 @@ export function buildCalendar(container: HTMLElement, initialDate: string, onSel
             const dStr = `${vY}-${pad(vM + 1)}-${pad(i)}`;
             const isSel = dStr === activeDateStr;
             const bg = isSel ? 'var(--accent-blue)' : 'transparent';
-            const fg = isSel ? '#fff' : 'var(--text-primary)';
+            const fg = isSel ? 'var(--text-on-fill)' : 'var(--text-primary)';
             
             const today = new Date();
             const todayStr = `${today.getFullYear()}-${pad(today.getMonth() + 1)}-${pad(today.getDate())}`;

--- a/src/dashboard/ActivityCharts.ts
+++ b/src/dashboard/ActivityCharts.ts
@@ -298,11 +298,11 @@ export class ActivityCharts extends Component<ActivityChartsState> {
     private getChartColors(): string[] {
         const style = getComputedStyle(document.body);
         return [
-            style.getPropertyValue('--chart-1').trim() || '#f4a6b8',
-            style.getPropertyValue('--chart-2').trim() || '#b8cdda',
-            style.getPropertyValue('--chart-3').trim() || '#e0bbe4',
-            style.getPropertyValue('--chart-4').trim() || '#957DAD',
-            style.getPropertyValue('--chart-5').trim() || '#D291BC'
+            style.getPropertyValue('--chart-1').trim(),
+            style.getPropertyValue('--chart-2').trim(),
+            style.getPropertyValue('--chart-3').trim(),
+            style.getPropertyValue('--chart-4').trim(),
+            style.getPropertyValue('--chart-5').trim()
         ];
     }
 
@@ -356,7 +356,7 @@ export class ActivityCharts extends Component<ActivityChartsState> {
                 responsive: true,
                 maintainAspectRatio: false,
                 plugins: {
-                    legend: { display: data.labels.length <= 6, position: 'bottom', labels: { color: style.getPropertyValue('--text-secondary').trim() ||'#f0f0f5' } },
+                    legend: { display: data.labels.length <= 6, position: 'bottom', labels: { color: style.getPropertyValue('--text-secondary').trim() } },
                     tooltip: {
                         callbacks: {
                             label: (context) => {
@@ -377,8 +377,8 @@ export class ActivityCharts extends Component<ActivityChartsState> {
         const { chartType } = this.state;
         const { labels } = timeRange;
         const style = getComputedStyle(document.body);
-        const secondaryColor = style.getPropertyValue('--text-secondary').trim() || '#a0a0b0'
-        const gridColor = `color-mix(in srgb, ${style.getPropertyValue('--text-secondary').trim() || '#3f3f4e'} 30%, transparent)`;
+        const secondaryColor = style.getPropertyValue('--text-secondary').trim()
+        const gridColor = `color-mix(in srgb, ${secondaryColor} 30%, transparent)`;
         const datasets = measureSynchronous(
             'aggregation',
             'dashboard_bar_data',

--- a/src/dashboard/HeatmapView.ts
+++ b/src/dashboard/HeatmapView.ts
@@ -94,16 +94,13 @@ export class HeatmapView extends Component<HeatmapViewState> {
         }
 
         const style = getComputedStyle(document.body);
-        const getThemeNum = (v: string, def: number) => {
-            const s = style.getPropertyValue(v).trim();
-            return s === "" ? def : Number.parseFloat(s);
-        };
+        const getThemeNum = (v: string) => Number.parseFloat(style.getPropertyValue(v).trim());
 
-        const heatmapHue = style.getPropertyValue('--heatmap-hue').trim() || '353';
-        const satBase = getThemeNum('--heatmap-sat-base', 30);
-        const satRange = getThemeNum('--heatmap-sat-range', 70);
-        const lightBase = getThemeNum('--heatmap-light-base', 45);
-        const lightRange = getThemeNum('--heatmap-light-range', 41);
+        const heatmapHue = style.getPropertyValue('--heatmap-hue').trim();
+        const satBase = getThemeNum('--heatmap-sat-base');
+        const satRange = getThemeNum('--heatmap-sat-range');
+        const lightBase = getThemeNum('--heatmap-light-base');
+        const lightRange = getThemeNum('--heatmap-light-range');
 
         const todayStr = this.getLocalISODate(new Date());
 

--- a/src/dashboard/QuickLog.ts
+++ b/src/dashboard/QuickLog.ts
@@ -177,7 +177,7 @@ export class QuickLog extends Component<QuickLogState> {
                         <svg viewBox="0 0 24 24" fill="none">
                             <path
                                 d="M8 5L16 12L8 19"
-                                stroke="white"
+                                stroke="currentColor"
                                 stroke-width="2.5"
                                 stroke-linecap="round"
                                 stroke-linejoin="round"

--- a/src/dashboard/StatsCard.ts
+++ b/src/dashboard/StatsCard.ts
@@ -181,7 +181,7 @@ export class StatsCard extends Component<StatsCardState> {
                     </div>` : '';
 
             return `
-                <div class="study-stats-breakdown-item" style="display: flex; flex-direction: column; gap: 0.2rem; background: rgba(255,255,255,0.03); padding: 0.4rem; border-radius: var(--radius-sm);">
+                <div class="study-stats-breakdown-item" style="display: flex; flex-direction: column; gap: 0.2rem; background: color-mix(in srgb, var(--tint-light) 3%, transparent); padding: 0.4rem; border-radius: var(--radius-sm);">
                     <div style="display: flex; justify-content: space-between; font-size: 0.85rem;">
                         <span style="color: var(--text-secondary);">${mtype}</span>
                         <span style="font-weight: bold; color: var(--text-primary);">${totalFormat}</span>

--- a/src/main.ts
+++ b/src/main.ts
@@ -98,8 +98,8 @@ function renderStartupErrorScreen(message: string): void {
 
     appRoot.innerHTML = `
         <main style="min-height: 100vh; display: grid; place-items: center; padding: 2rem; background: linear-gradient(180deg, var(--bg-darkest), var(--bg-dark));">
-            <section style="width: min(92vw, 720px); border: 1px solid var(--border-color); border-radius: var(--radius-lg); background: color-mix(in srgb, var(--bg-dark) 92%, black); box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35); padding: 2rem;" role="alertdialog" aria-live="assertive">
-                <p style="margin: 0; color: var(--accent-red, #ff7b7b); font-size: 0.82rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;">Startup blocked</p>
+            <section style="width: min(92vw, 720px); border: 1px solid var(--border-color); border-radius: var(--radius-lg); background: color-mix(in srgb, var(--bg-dark) 92%, black); box-shadow: 0 24px 80px color-mix(in srgb, var(--tint-dark) 35%, transparent); padding: 2rem;" role="alertdialog" aria-live="assertive">
+                <p style="margin: 0; color: var(--accent-red); font-size: 0.82rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;">Startup blocked</p>
                 <h1 style="margin: 0.75rem 0 0; font-size: clamp(1.6rem, 3vw, 2.2rem);">${heading}</h1>
                 <p id="alert-body" style="margin: 1rem 0 0; color: var(--text-secondary); line-height: 1.7; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word;">${escapedMessage}</p>
                 <p id="startup-error-message" style="display: none;">${escapedMessage}</p>

--- a/src/media/MediaDetail.ts
+++ b/src/media/MediaDetail.ts
@@ -524,11 +524,11 @@ export class MediaDetail extends Component<MediaDetailState> {
                                         <circle cx="13" cy="8" r="1.5"/>
                                     </svg>
                                 </button>
-                                <div id="media-overflow-menu" hidden style="position: absolute; top: calc(100% + 0.5rem); right: 0; min-width: 12rem; padding: 0.35rem; border: 1px solid var(--border-color); border-radius: 12px; background: color-mix(in srgb, var(--bg-card) 94%, black 6%); box-shadow: 0 18px 50px rgba(0, 0, 0, 0.35); z-index: 20;">
+                                <div id="media-overflow-menu" hidden style="position: absolute; top: calc(100% + 0.5rem); right: 0; min-width: 12rem; padding: 0.35rem; border: 1px solid var(--border-color); border-radius: 12px; background: color-mix(in srgb, var(--bg-card) 94%, black 6%); box-shadow: 0 18px 50px color-mix(in srgb, var(--tint-dark) 35%, transparent); z-index: 20;">
                                     <button
                                         type="button"
                                         id="btn-delete-media-detail"
-                                        style="width: 100%; display: flex; align-items: center; gap: 0.5rem; padding: 0.55rem 0.7rem; border: none; border-radius: 9px; background: transparent; color: #ff7582; font: inherit; font-size: 0.9rem; text-align: left; cursor: pointer;">
+                                        style="width: 100%; display: flex; align-items: center; gap: 0.5rem; padding: 0.55rem 0.7rem; border: none; border-radius: 9px; background: transparent; color: var(--danger-muted); font: inherit; font-size: 0.9rem; text-align: left; cursor: pointer;">
                                         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M10 11v6M14 11v6"/></svg>
                                         Delete media
                                     </button>
@@ -562,7 +562,7 @@ export class MediaDetail extends Component<MediaDetailState> {
                                     ${rawHtml(this.renderMilestones())}
                                 </div>
                                 ${this.state.milestones.length > 0 ? html`
-                                    <div style="display: flex; justify-content: flex-end; margin-top: 0.5rem; padding-top: 0.5rem; border-top: 1px solid rgba(255,255,255,0.05);">
+                                    <div style="display: flex; justify-content: flex-end; margin-top: 0.5rem; padding-top: 0.5rem; border-top: 1px solid color-mix(in srgb, var(--tint-light) 5%, transparent);">
                                         <button class="btn btn-ghost" id="btn-clear-milestones" style="padding: 0.2rem 0.4rem; font-size: 0.6rem; border-radius: 4px; color: var(--accent-red); opacity: 0.6; font-weight: 500;">Delete all milestones</button>
                                     </div>
                                 ` : ''}
@@ -714,7 +714,7 @@ export class MediaDetail extends Component<MediaDetailState> {
         return this.state.milestones.map(m => {
             const dateHover = m.date ? `title="Achieved on ${escapeAttribute(m.date)}"` : '';
             return `
-                <div class="milestone-item" data-milestone-name="${escapeAttribute(m.name)}" ${dateHover} style="display: flex; align-items: center; justify-content: space-between; padding: 0.3rem 0.5rem; background: rgba(255,255,255,0.03); border-radius: 3px; border: 1px solid rgba(255,255,255,0.05); position: relative;">
+                <div class="milestone-item" data-milestone-name="${escapeAttribute(m.name)}" ${dateHover} style="display: flex; align-items: center; justify-content: space-between; padding: 0.3rem 0.5rem; background: color-mix(in srgb, var(--tint-light) 3%, transparent); border-radius: 3px; border: 1px solid color-mix(in srgb, var(--tint-light) 5%, transparent); position: relative;">
                     <div style="flex: 1; display: flex; flex-direction: column; gap: 0.05rem;">
                         <span style="font-weight: 600; font-size: 0.8rem; line-height: 1.1;">${escapeHTML(m.name)}</span>
                         <span style="font-size: 0.7rem; color: var(--text-secondary); opacity: 0.7;">

--- a/src/media/modal.ts
+++ b/src/media/modal.ts
@@ -285,14 +285,14 @@ export async function showJitenSearchModal(media: Media): Promise<string | null>
         overlay.innerHTML = `
             <div class="modal-content" style="max-width: 800px; width: 95vw; max-height: 90vh; display: flex; flex-direction: column; padding: 1.5rem;">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
-                    <h3 style="margin: 0; font-size: 1.5rem; font-weight: 700; color: #fff;">Search on Jiten.moe</h3>
+                    <h3 style="margin: 0; font-size: 1.5rem; font-weight: 700; color: var(--text-primary);">Search on Jiten.moe</h3>
                     <div id="jiten-back-container"></div>
                 </div>
                 <div style="position: relative; margin-bottom: 1rem;">
                     <input type="text" id="jiten-search-input" value="${escapeAttribute(media.title)}" style="width: 100%; padding: 0.8rem 2.8rem 0.8rem 1rem; border-radius: var(--radius-md); border: 1px solid var(--border-color); background: var(--bg-dark); color: var(--text-primary); font-size: 1rem; outline: none;" placeholder="Search for media..." />
                     <div id="jiten-search-clear" style="position: absolute; right: 1rem; top: 50%; transform: translateY(-50%); cursor: pointer; color: var(--text-secondary); opacity: 0.6; font-size: 1.2rem;">&times;</div>
                 </div>
-                <div id="jiten-results-container" style="flex: 1; overflow-y: auto; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: rgba(0,0,0,0.3); min-height: 350px; padding: 1.2rem;">
+                <div id="jiten-results-container" style="flex: 1; overflow-y: auto; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: var(--shadow-color); min-height: 350px; padding: 1.2rem;">
                     <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(130px, 1fr)); gap: 1.2rem;" id="jiten-results-grid"></div>
                 </div>
                 <div style="margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid var(--border-color); display: flex; flex-direction: column; gap: 0.8rem;">
@@ -361,14 +361,14 @@ export async function showJitenSearchModal(media: Media): Promise<string | null>
 
 function renderJitenResults(grid: HTMLElement, results: JitenResult[], onSelect: (res: JitenResult) => void) {
     grid.innerHTML = results.map(res => `
-        <div class="jiten-result-card" data-id="${escapeAttribute(String(res.deckId))}" style="cursor: pointer; background: #1a151f; border: 1px solid var(--border-color); border-radius: var(--radius-md); overflow: hidden; display: flex; flex-direction: column; transition: transform 0.2s; position: relative;">
-            <div style="aspect-ratio: 2/3; position: relative; background: #000; display: flex; align-items: center; justify-content: center; overflow: hidden;">
+        <div class="jiten-result-card" data-id="${escapeAttribute(String(res.deckId))}" style="cursor: pointer; background: var(--bg-elevated); border: 1px solid var(--border-color); border-radius: var(--radius-md); overflow: hidden; display: flex; flex-direction: column; transition: transform 0.2s; position: relative;">
+            <div style="aspect-ratio: 2/3; position: relative; background: var(--tint-dark); display: flex; align-items: center; justify-content: center; overflow: hidden;">
                 <img src="${escapeAttribute(getJitenCoverUrl(res.deckId, res.parentDeckId))}" style="max-width: 100%; max-height: 100%; object-fit: contain; min-height: 100%;" />
-                <div style="position: absolute; bottom: 0; left: 0; right: 0; background: rgba(0,0,0,0.73); color: white; padding: 0.2rem 0.4rem; font-size: 0.65rem; font-weight: 600; text-transform: uppercase;">
+                <div style="position: absolute; bottom: 0; left: 0; right: 0; background: color-mix(in srgb, var(--tint-dark) 73%, transparent); color: var(--text-on-fill); padding: 0.2rem 0.4rem; font-size: 0.65rem; font-weight: 600; text-transform: uppercase;">
                     ${escapeHTML(getJitenMediaLabel(res.mediaType))}
                 </div>
             </div>
-            <div style="padding: 0.6rem 0.4rem; flex: 1; display: flex; align-items: center; justify-content: center; background: rgba(255,255,255,0.02);">
+            <div style="padding: 0.6rem 0.4rem; flex: 1; display: flex; align-items: center; justify-content: center; background: color-mix(in srgb, var(--tint-light) 2%, transparent);">
                 <div style="font-size: 0.75rem; font-weight: 600; color: var(--text-primary); text-align: center; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; line-height: 1.3;">${escapeHTML(res.originalTitle)}</div>
             </div>
         </div>`).join('');
@@ -384,14 +384,14 @@ function renderJitenResults(grid: HTMLElement, results: JitenResult[], onSelect:
 
 function renderJitenVolumes(grid: HTMLElement, parent: JitenResult, children: JitenResult[], onSelect: (id: number) => void) {
     grid.innerHTML = [
-        `<div class="jiten-result-card jiten-volume-card" data-deck-id="${escapeAttribute(String(parent.deckId))}" style="cursor: pointer; background: #1a151f; border: 2px solid var(--accent-blue); border-radius: var(--radius-md); overflow: hidden; display: flex; flex-direction: column; transition: transform 0.2s; position: relative;">
-            <div style="aspect-ratio: 2/3; position: relative; background: #000; display: flex; align-items: center; justify-content: center;"><img src="${escapeAttribute(getJitenCoverUrl(parent.deckId, parent.parentDeckId))}" style="max-width: 100%; max-height: 100%; object-fit: contain; min-height: 100%;" /></div>
-            <div style="padding: 0.6rem 0.4rem; flex: 1; display: flex; align-items: center; justify-content: center; background: #2a2135;"><div style="font-size: 0.8rem; font-weight: 800; color: #fff; text-align: center;">Entire Series</div></div>
+        `<div class="jiten-result-card jiten-volume-card" data-deck-id="${escapeAttribute(String(parent.deckId))}" style="cursor: pointer; background: var(--bg-elevated); border: 2px solid var(--accent-blue); border-radius: var(--radius-md); overflow: hidden; display: flex; flex-direction: column; transition: transform 0.2s; position: relative;">
+            <div style="aspect-ratio: 2/3; position: relative; background: var(--tint-dark); display: flex; align-items: center; justify-content: center;"><img src="${escapeAttribute(getJitenCoverUrl(parent.deckId, parent.parentDeckId))}" style="max-width: 100%; max-height: 100%; object-fit: contain; min-height: 100%;" /></div>
+            <div style="padding: 0.6rem 0.4rem; flex: 1; display: flex; align-items: center; justify-content: center; background: var(--bg-elevated-alt);"><div style="font-size: 0.8rem; font-weight: 800; color: var(--text-on-fill); text-align: center;">Entire Series</div></div>
         </div>`,
         ...children.map((res, i) => `
-        <div class="jiten-result-card jiten-volume-card" data-deck-id="${escapeAttribute(String(res.deckId))}" style="cursor: pointer; background: #1a151f; border: 1px solid var(--border-color); border-radius: var(--radius-md); overflow: hidden; display: flex; flex-direction: column; transition: transform 0.2s; position: relative;">
-            <div style="aspect-ratio: 2/3; position: relative; background: #000; display: flex; align-items: center; justify-content: center;"><img src="${escapeAttribute(getJitenCoverUrl(res.deckId, res.parentDeckId || parent.deckId))}" style="max-width: 100%; max-height: 100%; object-fit: contain; opacity: 0.9; min-height: 100%;" /><div style="position: absolute; top: 0.3rem; left: 0.3rem; background: rgba(0,0,0,0.7); color: #fff; min-width: 1.3rem; height: 1.3rem; border-radius: 4px; display: flex; align-items: center; justify-content: center; font-size: 0.7rem; font-weight: 900; border: 1px solid rgba(255,255,255,0.2);">${i+1}</div></div>
-            <div style="padding: 0.6rem 0.4rem; flex: 1; display: flex; align-items: center; justify-content: center; background: rgba(255,255,255,0.02);"><div style="font-size: 0.75rem; font-weight: 600; color: var(--text-primary); text-align: center;">${escapeHTML(res.originalTitle)}</div></div>
+        <div class="jiten-result-card jiten-volume-card" data-deck-id="${escapeAttribute(String(res.deckId))}" style="cursor: pointer; background: var(--bg-elevated); border: 1px solid var(--border-color); border-radius: var(--radius-md); overflow: hidden; display: flex; flex-direction: column; transition: transform 0.2s; position: relative;">
+            <div style="aspect-ratio: 2/3; position: relative; background: var(--tint-dark); display: flex; align-items: center; justify-content: center;"><img src="${escapeAttribute(getJitenCoverUrl(res.deckId, res.parentDeckId || parent.deckId))}" style="max-width: 100%; max-height: 100%; object-fit: contain; opacity: 0.9; min-height: 100%;" /><div style="position: absolute; top: 0.3rem; left: 0.3rem; background: color-mix(in srgb, var(--tint-dark) 70%, transparent); color: var(--text-on-fill); min-width: 1.3rem; height: 1.3rem; border-radius: 4px; display: flex; align-items: center; justify-content: center; font-size: 0.7rem; font-weight: 900; border: 1px solid color-mix(in srgb, var(--tint-light) 20%, transparent);">${i+1}</div></div>
+            <div style="padding: 0.6rem 0.4rem; flex: 1; display: flex; align-items: center; justify-content: center; background: color-mix(in srgb, var(--tint-light) 2%, transparent);"><div style="font-size: 0.75rem; font-weight: 600; color: var(--text-primary); text-align: center;">${escapeHTML(res.originalTitle)}</div></div>
         </div>`)
     ].join('');
     

--- a/src/modal_base.ts
+++ b/src/modal_base.ts
@@ -251,8 +251,8 @@ export function showBlockingStatus(title: string, text: string): BlockingStatusH
                 <div aria-hidden="true" style="width: 28px; height: 28px; border-radius: 999px; border: 3px solid var(--border-color); border-top-color: var(--accent-blue); animation: spin 0.8s linear infinite;"></div>
             </div>
             <div id="blocking-status-progress" style="display: none; margin-top: 1.25rem;">
-                <div style="width: 100%; height: 10px; border-radius: 999px; background: rgba(255,255,255,0.08); overflow: hidden;">
-                    <div id="blocking-status-progress-bar" style="width: 0%; height: 100%; background: linear-gradient(90deg, var(--accent-blue), #6ee7f9); transition: width 0.18s ease;"></div>
+                <div style="width: 100%; height: 10px; border-radius: 999px; background: color-mix(in srgb, var(--tint-light) 8%, transparent); overflow: hidden;">
+                    <div id="blocking-status-progress-bar" style="width: 0%; height: 100%; background: linear-gradient(90deg, var(--accent-blue), var(--info-bright)); transition: width 0.18s ease;"></div>
                 </div>
                 <p id="blocking-status-progress-label" style="margin-top: 0.65rem; font-size: 0.84rem; color: var(--text-secondary);">0 / 0</p>
             </div>

--- a/src/profile/ProfileView.ts
+++ b/src/profile/ProfileView.ts
@@ -215,15 +215,15 @@ function formatSyncStatusLabel(syncStatus: SyncStatus): string {
 function syncStateColor(state: SyncConnectionState): string {
     switch (state) {
         case 'connected_clean':
-            return '#2ed573';
+            return 'var(--success)';
         case 'dirty':
-            return '#f59e0b';
+            return 'var(--warning)';
         case 'syncing':
             return 'var(--accent-blue)';
         case 'conflict_pending':
-            return '#ff7f50';
+            return 'var(--highlight)';
         case 'error':
-            return '#ff4757';
+            return 'var(--danger)';
         case 'disconnected':
         default:
             return 'var(--text-secondary)';
@@ -232,7 +232,7 @@ function syncStateColor(state: SyncConnectionState): string {
 
 function syncStatusColor(syncStatus: SyncStatus): string {
     if (syncStatus.sync_profile_id && !syncStatus.google_authenticated) {
-        return '#ff4757';
+        return 'var(--danger)';
     }
     return syncStateColor(syncStatus.state);
 }
@@ -268,10 +268,10 @@ function profilePictureLabel(picture: SyncConflictProfilePicture | null): string
 
 function syncCardBorderColor(state: SyncConnectionState): string {
     if (state === 'error') {
-        return 'rgba(255, 71, 87, 0.25)';
+        return 'color-mix(in srgb, var(--danger) 25%, transparent)';
     }
     if (state === 'conflict_pending') {
-        return 'rgba(255, 127, 80, 0.25)';
+        return 'color-mix(in srgb, var(--highlight) 25%, transparent)';
     }
     return 'var(--border-color)';
 }
@@ -676,24 +676,24 @@ export class ProfileView extends Component<ProfileState> {
                     </div>
                 </div>
 
-                <div class="card" style="display: flex; flex-direction: column; gap: 1rem; border: 1px solid #ff4757;">
-                    <h3 style="color: #ff4757;">Danger Zone</h3>
+                <div class="card" style="display: flex; flex-direction: column; gap: 1rem; border: 1px solid var(--danger);">
+                    <h3 style="color: var(--danger);">Danger Zone</h3>
 
                     <div style="display: flex; flex-direction: column; gap: 1rem; margin-top: 0.5rem;">
                         <div style="display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding-bottom: 1rem; border-bottom: 1px solid var(--border-color);">
                             <div>
-                                <strong style="color: #ff4757;">Clear User Activities</strong>
+                                <strong style="color: var(--danger);">Clear User Activities</strong>
                                 <p style="color: var(--text-secondary); font-size: 0.8rem; margin: 0;">Removes all recorded activity logs, but keeps the profile and media library intact.</p>
                             </div>
-                            <button class="btn btn-danger" id="profile-btn-clear-activities" style="background-color: transparent !important; border: 1px solid #ff4757; color: #ff4757 !important; min-width: 140px;">Clear Activities</button>
+                            <button class="btn btn-danger" id="profile-btn-clear-activities" style="background-color: transparent !important; border: 1px solid var(--danger); color: var(--danger) !important; min-width: 140px;">Clear Activities</button>
                         </div>
 
                         <div style="display: flex; align-items: center; justify-content: space-between; gap: 1rem;">
                             <div>
-                                <strong style="color: #ff4757;">Delete Everything</strong>
+                                <strong style="color: var(--danger);">Delete Everything</strong>
                                 <p style="color: var(--text-secondary); font-size: 0.8rem; margin: 0;">Perform a total factory reset. Deletes ALL profiles, ALL activity logs, and the ENTIRE media library along with its cover images. Irreversible.</p>
                             </div>
-                            <button class="btn btn-danger" id="profile-btn-wipe-everything" style="background-color: darkred !important; color: #ffffff !important; border: none; min-width: 140px; font-weight: bold;">Factory Reset</button>
+                            <button class="btn btn-danger" id="profile-btn-wipe-everything" style="background-color: var(--danger-strong) !important; color: var(--text-on-fill) !important; border: none; min-width: 140px; font-weight: bold;">Factory Reset</button>
                         </div>
                     </div>
                 </div>
@@ -738,11 +738,11 @@ export class ProfileView extends Component<ProfileState> {
 
         return html`
             <div style="display: flex; flex-direction: column; gap: 0.75rem;">
-                <div style="display: flex; justify-content: space-between; border-bottom: 1px solid rgba(255,255,255,0.05); padding-bottom: 0.5rem;">
+                <div style="display: flex; justify-content: space-between; border-bottom: 1px solid color-mix(in srgb, var(--tint-light) 5%, transparent); padding-bottom: 0.5rem;">
                     <span>Average Novel Reading Speed: <strong>${Number.parseInt(report.novelSpeed, 10).toLocaleString()} char/hr</strong></span>
                     <span style="color: var(--text-secondary); font-size: 0.85rem;">(out of ${report.novelCount} books)</span>
                 </div>
-                <div style="display: flex; justify-content: space-between; border-bottom: 1px solid rgba(255,255,255,0.05); padding-bottom: 0.5rem;">
+                <div style="display: flex; justify-content: space-between; border-bottom: 1px solid color-mix(in srgb, var(--tint-light) 5%, transparent); padding-bottom: 0.5rem;">
                     <span>Average Manga Reading Speed: <strong>${Number.parseInt(report.mangaSpeed, 10).toLocaleString()} char/hr</strong></span>
                     <span style="color: var(--text-secondary); font-size: 0.85rem;">(out of ${report.mangaCount} manga)</span>
                 </div>
@@ -880,12 +880,12 @@ export class ProfileView extends Component<ProfileState> {
         }
 
         const runningLabel = status.running ? 'Running' : 'Stopped';
-        const runningColor = status.running ? '#2ed573' : 'var(--text-secondary)';
+        const runningColor = status.running ? 'var(--success)' : 'var(--text-secondary)';
         const lanEnabled = status.bindHost === '0.0.0.0';
         const originsText = status.allowedOrigins.join('\n');
 
         return html`
-            <div class="card" id="profile-local-http-api-card" style="display: flex; flex-direction: column; gap: 1rem; border: 1px solid ${status.enabled ? 'rgba(245, 158, 11, 0.35)' : 'var(--border-color)'};">
+            <div class="card" id="profile-local-http-api-card" style="display: flex; flex-direction: column; gap: 1rem; border: 1px solid ${status.enabled ? 'color-mix(in srgb, var(--warning) 35%, transparent)' : 'var(--border-color)'};">
                 <div style="display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem; flex-wrap: wrap;">
                     <div style="display: flex; flex-direction: column; gap: 0.45rem;">
                         <h3 style="margin: 0;">HTTP API</h3>
@@ -913,7 +913,7 @@ export class ProfileView extends Component<ProfileState> {
 
                 ${status.url
                     ? html`
-                        <div style="display: flex; flex-direction: column; gap: 0.25rem; padding: 0.75rem 0.9rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: rgba(255,255,255,0.02);">
+                        <div style="display: flex; flex-direction: column; gap: 0.25rem; padding: 0.75rem 0.9rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: color-mix(in srgb, var(--tint-light) 2%, transparent);">
                             <span style="font-size: 0.78rem; color: var(--text-secondary);">Endpoint</span>
                             <code style="color: var(--text-primary); overflow-wrap: anywhere;">${status.url}</code>
                         </div>
@@ -922,7 +922,7 @@ export class ProfileView extends Component<ProfileState> {
 
                 ${status.lastError
                     ? html`
-                        <div style="padding: 0.75rem 0.9rem; border-radius: var(--radius-md); border: 1px solid rgba(255, 71, 87, 0.35); background: rgba(255, 71, 87, 0.08); color: var(--text-primary); font-size: 0.88rem;">
+                        <div style="padding: 0.75rem 0.9rem; border-radius: var(--radius-md); border: 1px solid color-mix(in srgb, var(--danger) 35%, transparent); background: color-mix(in srgb, var(--danger) 8%, transparent); color: var(--text-primary); font-size: 0.88rem;">
                             ${status.lastError}
                         </div>
                     `
@@ -931,7 +931,7 @@ export class ProfileView extends Component<ProfileState> {
                 <details id="profile-local-api-advanced" style="border: 1px solid var(--border-color); border-radius: var(--radius-md); padding: 0.75rem 0.9rem;">
                     <summary style="cursor: pointer; color: var(--text-primary); font-weight: 600;">Advanced settings</summary>
                     <div style="display: flex; flex-direction: column; gap: 0.85rem; margin-top: 1rem;">
-                        <div style="padding: 0.9rem 1rem; border-radius: var(--radius-md); border: 1px solid rgba(245, 158, 11, 0.35); background: rgba(245, 158, 11, 0.08); color: var(--text-primary); font-size: 0.88rem; line-height: 1.45;">
+                        <div style="padding: 0.9rem 1rem; border-radius: var(--radius-md); border: 1px solid color-mix(in srgb, var(--warning) 35%, transparent); background: color-mix(in srgb, var(--warning) 8%, transparent); color: var(--text-primary); font-size: 0.88rem; line-height: 1.45;">
                             This API is unauthenticated. While enabled, local programs can read and change Kechimochi data. LAN access lets other devices on your network do the same. Full API mode also exposes import, export, reset, cover upload, and network proxy endpoints.
                         </div>
 
@@ -1005,10 +1005,10 @@ export class ProfileView extends Component<ProfileState> {
 
     private renderSyncUnavailableCard(message: string) {
         return html`
-            <div class="card" id="profile-sync-card" style="display: flex; flex-direction: column; gap: 1rem; border: 1px solid rgba(255, 71, 87, 0.25);">
+            <div class="card" id="profile-sync-card" style="display: flex; flex-direction: column; gap: 1rem; border: 1px solid color-mix(in srgb, var(--danger) 25%, transparent);">
                 <div style="display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap;">
                     <h3 style="margin: 0;">Cloud Sync</h3>
-                    <span style="font-size: 0.8rem; color: #ff4757; border: 1px solid rgba(255, 71, 87, 0.35); border-radius: 999px; padding: 0.2rem 0.65rem;">Unavailable</span>
+                    <span style="font-size: 0.8rem; color: var(--danger); border: 1px solid color-mix(in srgb, var(--danger) 35%, transparent); border-radius: 999px; padding: 0.2rem 0.65rem;">Unavailable</span>
                 </div>
                 <p style="color: var(--text-secondary); font-size: 0.9rem; margin: 0;">${message}</p>
                 <div style="display: flex; justify-content: flex-end;">
@@ -1050,7 +1050,7 @@ export class ProfileView extends Component<ProfileState> {
 
                 ${this.state.syncError
                     ? html`
-                        <div style="padding: 0.9rem 1rem; border-radius: var(--radius-md); border: 1px solid rgba(255, 71, 87, 0.35); background: rgba(255, 71, 87, 0.08); color: var(--text-primary);">
+                        <div style="padding: 0.9rem 1rem; border-radius: var(--radius-md); border: 1px solid color-mix(in srgb, var(--danger) 35%, transparent); background: color-mix(in srgb, var(--danger) 8%, transparent); color: var(--text-primary);">
                             ${this.state.syncError}
                         </div>
                     `
@@ -1077,7 +1077,7 @@ export class ProfileView extends Component<ProfileState> {
         const chips: HTMLElement[] = [];
         if (hasConflicts) {
             chips.push(html`
-                <span style="font-size: 0.76rem; color: var(--text-primary); border: 1px solid rgba(255, 127, 80, 0.35); border-radius: 999px; padding: 0.22rem 0.65rem; background: rgba(255, 127, 80, 0.08);">
+                <span style="font-size: 0.76rem; color: var(--text-primary); border: 1px solid color-mix(in srgb, var(--highlight) 35%, transparent); border-radius: 999px; padding: 0.22rem 0.65rem; background: color-mix(in srgb, var(--highlight) 8%, transparent);">
                     ${syncStatus.conflict_count} pending conflict${syncStatus.conflict_count === 1 ? '' : 's'}
                 </span>
             `);
@@ -1143,7 +1143,7 @@ export class ProfileView extends Component<ProfileState> {
         const toggleLabel = this.state.showSyncRecoveryTools ? 'Hide tools' : 'Show tools';
 
         return html`
-            <div style="display: flex; flex-direction: column; gap: 0.75rem; padding: 0.9rem 1rem; border-radius: var(--radius-md); border: 1px solid var(--border-color); background: rgba(255,255,255,0.02);">
+            <div style="display: flex; flex-direction: column; gap: 0.75rem; padding: 0.9rem 1rem; border-radius: var(--radius-md); border: 1px solid var(--border-color); background: color-mix(in srgb, var(--tint-light) 2%, transparent);">
                 <button
                     id="profile-btn-toggle-sync-recovery"
                     type="button"
@@ -1159,7 +1159,7 @@ export class ProfileView extends Component<ProfileState> {
                 </button>
                 ${this.state.showSyncRecoveryTools
                     ? html`
-                        <div style="display: flex; flex-direction: column; gap: 0.75rem; padding: 0.9rem 1rem; border-radius: var(--radius-md); border: 1px solid rgba(255, 71, 87, 0.28); background: rgba(255, 71, 87, 0.06);">
+                        <div style="display: flex; flex-direction: column; gap: 0.75rem; padding: 0.9rem 1rem; border-radius: var(--radius-md); border: 1px solid color-mix(in srgb, var(--danger) 28%, transparent); background: color-mix(in srgb, var(--danger) 6%, transparent);">
                             <span style="color: var(--text-secondary); font-size: 0.85rem;">
                                 These actions are destructive. ${hint}
                             </span>
@@ -1236,7 +1236,7 @@ export class ProfileView extends Component<ProfileState> {
     private renderSyncInfoTile(label: string, value: string, fullWidth = false, extra?: HTMLElement) {
         const spanStyle = fullWidth ? 'grid-column: 1 / -1;' : '';
         return html`
-            <div style="${spanStyle} display: flex; flex-direction: column; gap: 0.25rem; padding: 0.9rem 1rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: rgba(255,255,255,0.02);">
+            <div style="${spanStyle} display: flex; flex-direction: column; gap: 0.25rem; padding: 0.9rem 1rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: color-mix(in srgb, var(--tint-light) 2%, transparent);">
                 <span style="font-size: 0.78rem; color: var(--text-secondary);">${label}</span>
                 <strong style="font-size: 0.96rem; color: var(--text-primary);">${value}</strong>
                 ${extra || ''}
@@ -1273,7 +1273,7 @@ export class ProfileView extends Component<ProfileState> {
 
     private renderDuplicateMediaIdentityConflict(conflict: Extract<SyncConflict, { kind: 'duplicate_media_identity' }>, index: number) {
         const renderMediaSummary = (label: string, media: typeof conflict.local_media) => html`
-            <div style="display: flex; flex-direction: column; gap: 0.35rem; padding: 0.9rem 1rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: rgba(255,255,255,0.02);">
+            <div style="display: flex; flex-direction: column; gap: 0.35rem; padding: 0.9rem 1rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: color-mix(in srgb, var(--tint-light) 2%, transparent);">
                 <span style="font-size: 0.8rem; color: var(--text-secondary);">${label}</span>
                 <strong style="color: var(--text-primary);">${media.title}</strong>
                 <span style="font-size: 0.82rem; color: var(--text-secondary);">Variant: ${media.variant || '(none)'}</span>
@@ -1299,7 +1299,7 @@ export class ProfileView extends Component<ProfileState> {
         };
 
         return html`
-            <div class="sync-duplicate-media-conflict" data-sync-duplicate-conflict-index="${index}" style="display: flex; flex-direction: column; gap: 0.8rem; padding: 1rem; border: 1px solid rgba(255, 127, 80, 0.24); border-radius: var(--radius-md); background: rgba(255, 127, 80, 0.05);">
+            <div class="sync-duplicate-media-conflict" data-sync-duplicate-conflict-index="${index}" style="display: flex; flex-direction: column; gap: 0.8rem; padding: 1rem; border: 1px solid color-mix(in srgb, var(--highlight) 24%, transparent); border-radius: var(--radius-md); background: color-mix(in srgb, var(--highlight) 5%, transparent);">
                 <div style="display: flex; flex-direction: column; gap: 0.25rem;">
                     <strong>Duplicate media identity conflict</strong>
                     <span style="color: var(--text-secondary); font-size: 0.85rem;">Local and Cloud contain separate media entries with the same title and variant. Combine them, or rename one side before keeping both.</span>
@@ -1325,7 +1325,7 @@ export class ProfileView extends Component<ProfileState> {
             : conflict.media_uid;
 
         return html`
-            <div style="display: flex; flex-direction: column; gap: 0.8rem; padding: 1rem; border: 1px solid rgba(255, 127, 80, 0.24); border-radius: var(--radius-md); background: rgba(255, 127, 80, 0.05);">
+            <div style="display: flex; flex-direction: column; gap: 0.8rem; padding: 1rem; border: 1px solid color-mix(in srgb, var(--highlight) 24%, transparent); border-radius: var(--radius-md); background: color-mix(in srgb, var(--highlight) 5%, transparent);">
                 <div style="display: flex; justify-content: space-between; gap: 1rem; flex-wrap: wrap;">
                     <div style="display: flex; flex-direction: column; gap: 0.25rem;">
                         <strong>${formatFieldLabel(conflict.field_name)} conflict</strong>
@@ -1349,7 +1349,7 @@ export class ProfileView extends Component<ProfileState> {
         const remoteLabel = conflict.remote_value === null ? 'Discard entry' : 'Use Remote Entry';
 
         return html`
-            <div style="display: flex; flex-direction: column; gap: 0.8rem; padding: 1rem; border: 1px solid rgba(255, 127, 80, 0.24); border-radius: var(--radius-md); background: rgba(255, 127, 80, 0.05);">
+            <div style="display: flex; flex-direction: column; gap: 0.8rem; padding: 1rem; border: 1px solid color-mix(in srgb, var(--highlight) 24%, transparent); border-radius: var(--radius-md); background: color-mix(in srgb, var(--highlight) 5%, transparent);">
                 <div style="display: flex; justify-content: space-between; gap: 1rem; flex-wrap: wrap;">
                     <div style="display: flex; flex-direction: column; gap: 0.25rem;">
                         <strong>Extra data entry conflict</strong>
@@ -1377,7 +1377,7 @@ export class ProfileView extends Component<ProfileState> {
                 : conflict.local_media?.title || conflict.media_uid;
 
         return html`
-            <div style="display: flex; flex-direction: column; gap: 0.8rem; padding: 1rem; border: 1px solid rgba(255, 127, 80, 0.24); border-radius: var(--radius-md); background: rgba(255, 127, 80, 0.05);">
+            <div style="display: flex; flex-direction: column; gap: 0.8rem; padding: 1rem; border: 1px solid color-mix(in srgb, var(--highlight) 24%, transparent); border-radius: var(--radius-md); background: color-mix(in srgb, var(--highlight) 5%, transparent);">
                 <div style="display: flex; justify-content: space-between; gap: 1rem; flex-wrap: wrap;">
                     <div style="display: flex; flex-direction: column; gap: 0.25rem;">
                         <strong>Delete vs update conflict</strong>
@@ -1385,7 +1385,7 @@ export class ProfileView extends Component<ProfileState> {
                     </div>
                     <span style="font-size: 0.76rem; color: var(--text-secondary);">UID ${conflict.media_uid}</span>
                 </div>
-                <div style="padding: 0.9rem 1rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: rgba(255,255,255,0.02);">
+                <div style="padding: 0.9rem 1rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: color-mix(in srgb, var(--tint-light) 2%, transparent);">
                     <div style="font-size: 0.8rem; color: var(--text-secondary);">Restore candidate</div>
                     <div style="font-weight: 600; color: var(--text-primary);">${restoredTitle}</div>
                     <div style="font-size: 0.8rem; color: var(--text-secondary); margin-top: 0.35rem;">Deleted at ${formatSyncTimestamp(conflict.tombstone.deleted_at)}</div>
@@ -1400,7 +1400,7 @@ export class ProfileView extends Component<ProfileState> {
 
     private renderProfilePictureConflict(conflict: Extract<SyncConflict, { kind: 'profile_picture_conflict' }>, index: number) {
         return html`
-            <div style="display: flex; flex-direction: column; gap: 0.8rem; padding: 1rem; border: 1px solid rgba(255, 127, 80, 0.24); border-radius: var(--radius-md); background: rgba(255, 127, 80, 0.05);">
+            <div style="display: flex; flex-direction: column; gap: 0.8rem; padding: 1rem; border: 1px solid color-mix(in srgb, var(--highlight) 24%, transparent); border-radius: var(--radius-md); background: color-mix(in srgb, var(--highlight) 5%, transparent);">
                 <div style="display: flex; flex-direction: column; gap: 0.25rem;">
                     <strong>Profile picture conflict</strong>
                     <span style="color: var(--text-secondary); font-size: 0.85rem;">Choose which picture should become the synced version.</span>
@@ -1419,7 +1419,7 @@ export class ProfileView extends Component<ProfileState> {
 
     private renderSyncValueChoice(label: string, value: string, preformatted = false) {
         return html`
-            <div style="display: flex; flex-direction: column; gap: 0.4rem; padding: 0.9rem 1rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: rgba(255,255,255,0.02);">
+            <div style="display: flex; flex-direction: column; gap: 0.4rem; padding: 0.9rem 1rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: color-mix(in srgb, var(--tint-light) 2%, transparent);">
                 <span style="font-size: 0.8rem; color: var(--text-secondary);">${label}</span>
                 <pre style="margin: 0; white-space: pre-wrap; word-break: break-word; font-family: ${preformatted ? 'monospace' : 'inherit'}; font-size: 0.9rem; color: var(--text-primary);">${value}</pre>
             </div>
@@ -1429,9 +1429,9 @@ export class ProfileView extends Component<ProfileState> {
     private renderProfilePictureChoice(label: string, picture: SyncConflictProfilePicture | null) {
         const pictureSrc = picture ? profilePictureToDataUrl(picture as ProfilePicture) : null;
         return html`
-            <div style="display: flex; flex-direction: column; gap: 0.6rem; padding: 0.9rem 1rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: rgba(255,255,255,0.02);">
+            <div style="display: flex; flex-direction: column; gap: 0.6rem; padding: 0.9rem 1rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: color-mix(in srgb, var(--tint-light) 2%, transparent);">
                 <span style="font-size: 0.8rem; color: var(--text-secondary);">${label}</span>
-                <div style="display: flex; justify-content: center; align-items: center; min-height: 124px; padding: 0.75rem; border-radius: var(--radius-md); background: rgba(255,255,255,0.03);">
+                <div style="display: flex; justify-content: center; align-items: center; min-height: 124px; padding: 0.75rem; border-radius: var(--radius-md); background: color-mix(in srgb, var(--tint-light) 3%, transparent);">
                     ${pictureSrc
                         ? html`<img src="${pictureSrc}" alt="${label}" style="max-width: 100px; max-height: 100px; border-radius: 999px; object-fit: cover;" />`
                         : html`<span style="color: var(--text-secondary); font-size: 0.88rem;">No picture</span>`}

--- a/src/profile/reportcard/report_card_image.ts
+++ b/src/profile/reportcard/report_card_image.ts
@@ -50,29 +50,27 @@ export interface ReportCardImageOptions {
 
 /**
  * Reads CSS custom properties from the current document theme and returns a
- * typed color bundle used during canvas drawing. Falls back to safe hard-coded
- * defaults so the function is safe even when variables are absent.
+ * typed color bundle used during canvas drawing.
  */
 export function resolveReportCardThemeColors(): ReportCardThemeColors {
     const style = getComputedStyle(document.body);
 
-    function readVariable(name: string, fallback: string): string {
-        const value = style.getPropertyValue(name).trim();
-        return value.length > 0 ? value : fallback;
+    function readVariable(name: string): string {
+        return style.getPropertyValue(name).trim();
     }
 
     return {
-        backgroundColor: readVariable('--bg-dark', '#1e1e2e'),
-        cardBackgroundColor: readVariable('--bg-card', '#2a2a3e'),
-        primaryTextColor: readVariable('--text-primary', '#cdd6f4'),
-        secondaryTextColor: readVariable('--text-secondary', '#a6adc8'),
-        borderColor: readVariable('--border-color', '#45475a'),
+        backgroundColor: readVariable('--bg-dark'),
+        cardBackgroundColor: readVariable('--bg-card'),
+        primaryTextColor: readVariable('--text-primary'),
+        secondaryTextColor: readVariable('--text-secondary'),
+        borderColor: readVariable('--border-color'),
         chartColors: [
-            readVariable('--chart-1', '#f4a6b8'),
-            readVariable('--chart-2', '#b8cdda'),
-            readVariable('--chart-3', '#e0bbe4'),
-            readVariable('--chart-4', '#957DAD'),
-            readVariable('--chart-5', '#D291BC'),
+            readVariable('--chart-1'),
+            readVariable('--chart-2'),
+            readVariable('--chart-3'),
+            readVariable('--chart-4'),
+            readVariable('--chart-5'),
         ],
     };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -21,6 +21,27 @@
 
   --accent-text: #ffffff;
 
+  /* Palette Defaults */
+  --bg-dark: #2e232b;
+  --bg-card: #3d2e37;
+  --bg-card-hover: #4f3b47;
+  --text-primary: #fff0f5;
+  --text-secondary: #d8bfd8;
+  --accent-green: #ffb3ba;
+  --accent-green-hover: #ffdfba;
+  --accent-red: #ff9eaa;
+  --accent-blue: #b19cd9;
+  --accent-yellow: #fadadd;
+  --accent-purple: #f5c0c0;
+  --border-color: #554460;
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.2);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.3);
+  --chart-1: #f4a6b8;
+  --chart-2: #b8cdda;
+  --chart-3: #e0bbe4;
+  --chart-4: #957DAD;
+  --chart-5: #D291BC;
+
   /* Color Tokens */
   --tint-light: #ffffff;      /* base for translucent light tints and highlights */
   --tint-dark:  #000000;      /* base for translucent dark tints and depth */

--- a/src/styles.css
+++ b/src/styles.css
@@ -18,8 +18,48 @@
   --heatmap-sat-range: 70;
   --heatmap-light-base: 45;
   --heatmap-light-range: 41;
-  
+
   --accent-text: #ffffff;
+
+  /* Color Tokens */
+  --tint-light: #ffffff;      /* base for translucent light tints and highlights */
+  --tint-dark:  #000000;      /* base for translucent dark tints and depth */
+  --scrim:      rgba(0, 0, 0, 0.6);        /* modal overlay */
+  --shadow-color: rgba(0, 0, 0, 0.3);      /* default drop shadow */
+
+  --status-ongoing-led: #2196F3;      --status-ongoing-fill: #1c5a8a;      --status-ongoing-text: #ffffff;
+  --status-complete-led: #4CAF50;     --status-complete-fill: #1e8449;     --status-complete-text: #ffffff;
+  --status-paused-led: #FFEB3B;       --status-paused-fill: #f1c40f;       --status-paused-text: #000000;
+  --status-dropped-led: #F44336;      --status-dropped-fill: #c0392b;      --status-dropped-text: #ffffff;
+  --status-not-started-led: #FFFFFF;  --status-not-started-fill: #626567;  --status-not-started-text: #ffffff;
+
+  --danger: #ff4757;          /* ProfileView danger zone, calendar Sunday shares the value but NOT the meaning */
+  --danger-strong: #c0392b;   /* .alert-danger, status-dropped fill */
+  --danger-muted: #ff7582;    /* MediaDetail delete icon */
+  --warning: #f59e0b;         /* app-loader */
+
+  --accent-text-dark: #0f1b15;   /* dark-on-light-accent foreground */
+  /* Deliberately NOT overridden by any theme - white text on a saturated fill,
+     where --accent-text would flip to dark on the 6 themes that redefine it. */
+  --text-on-fill: #ffffff;
+  --switch-knob: #ffffff;     /* toggle knob face */
+
+  --info: #38bdf8;            /* informational callouts */
+  --info-bright: #6ee7f9;     /* progress bar gradient end */
+  --highlight: #ff7f50;       /* pending-conflict emphasis */
+
+  --bg-elevated: #1a151f;     /* jiten result cards */
+  --bg-elevated-alt: #2a2135; /* "Entire Series" section */
+  --heatmap-empty: #3b3b4a;   /* empty heatmap cell */
+  --calendar-sunday: #ff4757; --calendar-saturday: #1e90ff;   /* calendar.ts - semantic, kept separate from --danger */
+
+  --bg-boot: #06080c;         /* app startup loader backdrop */
+  --badge-tint: #f5c0c0;      /* .badge-content base tint */
+  --attention: #ff6384;       /* sync modal highlighted stat / conflict banner */
+  --warning-bright: #ffa600;  /* update modal backup warning */
+  --success: #2ed573;         /* sync connected, web server running */
+
+  --bg-darkest: color-mix(in srgb, var(--bg-dark) 92%, black);
 }
 
 .profile-avatar {
@@ -494,7 +534,7 @@ a {
 
 .btn-danger {
   background-color: var(--accent-red);
-  color: #fff;
+  color: var(--text-on-fill);
 }
 .btn-danger:hover {
   filter: brightness(1.1);
@@ -528,9 +568,9 @@ a {
   place-items: center;
   padding: 1.5rem;
   background:
-    radial-gradient(circle at top, rgba(255, 255, 255, 0.08), transparent 42%),
-    linear-gradient(180deg, rgba(6, 8, 12, 0.78), rgba(6, 8, 12, 0.92)),
-    var(--bg-dark, #121212);
+    radial-gradient(circle at top, color-mix(in srgb, var(--tint-light) 8%, transparent), transparent 42%),
+    linear-gradient(180deg, color-mix(in srgb, var(--bg-boot) 78%, transparent), color-mix(in srgb, var(--bg-boot) 92%, transparent)),
+    var(--bg-dark);
   z-index: 200;
   transition: opacity 0.18s ease, visibility 0.18s ease;
 }
@@ -545,7 +585,7 @@ a {
   width: 2.75rem;
   height: 2.75rem;
   border-radius: 999px;
-  border: 3px solid rgba(255, 255, 255, 0.12);
+  border: 3px solid color-mix(in srgb, var(--tint-light) 12%, transparent);
   border-top-color: var(--accent-green);
   animation: app-loader-spin 0.75s linear infinite;
 }
@@ -596,8 +636,8 @@ a {
 }
 
 .win-btn-close:hover {
-  background-color: #c0392b !important;
-  color: #fff !important;
+  background-color: var(--danger-strong) !important;
+  color: var(--text-on-fill) !important;
 }
 
 .app-nav-bar {
@@ -776,14 +816,14 @@ a {
 
 .nav-sync-status-btn[data-sync-state='dirty'] .sync-status-dot,
 .mobile-sync-status-btn[data-sync-state='dirty'] .sync-status-dot {
-  background: #f59e0b;
+  background: var(--warning);
 }
 
 .nav-sync-status-btn[data-sync-state='conflict'] .sync-status-dot,
 .nav-sync-status-btn[data-sync-state='error'] .sync-status-dot,
 .mobile-sync-status-btn[data-sync-state='conflict'] .sync-status-dot,
 .mobile-sync-status-btn[data-sync-state='error'] .sync-status-dot {
-  background: #ff4757;
+  background: var(--danger);
 }
 
 .nav-sync-status-btn[data-sync-state='syncing'] .sync-status-dot,
@@ -1251,7 +1291,7 @@ input:focus, select:focus {
 .timeline-kind-pill {
   padding: 0.3rem 0.72rem;
   background: color-mix(in srgb, var(--timeline-accent) 80%, black 20%);
-  color: #ffffff;
+  color: var(--text-on-fill);
 }
 
 .timeline-date-pill {
@@ -1413,7 +1453,7 @@ input:focus, select:focus {
 .modal-overlay {
   position: fixed;
   top: 0; left: 0; right: 0; bottom: 0;
-  background: rgba(0,0,0,0.6);
+  background: var(--scrim);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1471,7 +1511,7 @@ input:focus, select:focus {
   width: 100%;
   aspect-ratio: 1 / 1;
   border-radius: 2px;
-  background-color: #3b3b4a;
+  background-color: var(--heatmap-empty);
   min-width: 0;
 }
 
@@ -1720,12 +1760,12 @@ input:focus, select:focus {
   font-size: 0.75rem;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.04em;
   background-color: var(--accent-red);
-  color: #ffffff; /* Explicit white for contrast against red in most themes */
+  color: var(--text-on-fill);
   box-shadow: var(--shadow-sm);
   user-select: none;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid color-mix(in srgb, var(--tint-light) 10%, transparent);
   position: relative;
 }
 
@@ -1742,7 +1782,7 @@ input:focus, select:focus {
   border-radius: var(--radius-full);
   font-size: 0.75rem;
   font-weight: 700;
-  letter-spacing: 0.4px;
+  letter-spacing: 0.03em;
   background: color-mix(in srgb, var(--accent-blue) 22%, var(--bg-card));
   color: var(--text-primary);
   border: 1px solid color-mix(in srgb, var(--accent-blue) 55%, transparent);
@@ -1764,9 +1804,9 @@ input:focus, select:focus {
 }
 
 .badge-content {
-  background: rgba(245, 192, 192, 0.15);
+  background: color-mix(in srgb, var(--badge-tint) 15%, transparent);
   color: var(--accent-purple);
-  border: 1px solid rgba(245, 192, 192, 0.3);
+  border: 1px solid color-mix(in srgb, var(--badge-tint) 30%, transparent);
 }
 
 /* Fix for unreadable text in some themes */
@@ -1841,7 +1881,7 @@ input:focus, select:focus {
   letter-spacing: 1px;
   pointer-events: none;
   z-index: 5;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 10px color-mix(in srgb, var(--tint-dark) 40%, transparent);
   opacity: 0.95;
   white-space: nowrap;
 }
@@ -1934,7 +1974,7 @@ input:focus, select:focus {
   border-radius: var(--radius-full);
   border: 1px solid var(--border-color);
   background: color-mix(in srgb, var(--bg-card) 88%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--tint-light) 3%, transparent);
 }
 
 .toggle-option {
@@ -1953,7 +1993,7 @@ input:focus, select:focus {
 
 .toggle-option.is-active {
   background: var(--accent-green);
-  color: #0f1b15;
+  color: var(--accent-text-dark);
 }
 
 .toggle-option:disabled {
@@ -1973,7 +2013,7 @@ input:focus, select:focus {
   border: 1px solid var(--border-color);
   border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--bg-card) 88%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--tint-light) 3%, transparent);
 }
 
 .media-grid-zoom-button,
@@ -2061,7 +2101,7 @@ input:focus, select:focus {
   color: var(--text-primary);
   border-color: color-mix(in srgb, var(--accent-green) 65%, var(--border-color) 35%);
   background: color-mix(in srgb, var(--bg-card-hover) 92%, transparent);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--tint-dark) 12%, transparent);
 }
 
 .media-grid-filters-chevron {
@@ -2081,7 +2121,7 @@ input:focus, select:focus {
   padding: 0 0.35rem;
   border-radius: var(--radius-full);
   background: var(--accent-green);
-  color: #0f1b15;
+  color: var(--accent-text-dark);
   font-size: 0.68rem;
   font-weight: 800;
   line-height: 1;
@@ -2168,7 +2208,7 @@ input:focus, select:focus {
 .media-filter-chip.is-active {
   background: var(--accent-green);
   border-color: var(--accent-green);
-  color: #0f1b15;
+  color: var(--accent-text-dark);
 }
 
 .media-extra-filter-builder {
@@ -2417,7 +2457,7 @@ input:focus, select:focus {
 
 .media-sort-direction-option.is-active {
   background: var(--accent-green);
-  color: #0f1b15;
+  color: var(--accent-text-dark);
 }
 
 .media-sort-direction-option:disabled {
@@ -2718,7 +2758,7 @@ input:focus, select:focus {
 
 /* Tracking Status Colors */
 .badge-status {
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: 1px solid color-mix(in srgb, var(--tint-light) 10%, transparent);
     background: var(--bg-card-hover);
     color: var(--text-secondary);
 }
@@ -2733,27 +2773,27 @@ input:focus, select:focus {
     height: 10px;
     border-radius: 50%;
     z-index: 10;
-    box-shadow: 0 0 4px rgba(0, 0, 0, 0.5), inset 0 0 2px rgba(255, 255, 255, 0.3);
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    box-shadow: 0 0 4px color-mix(in srgb, var(--tint-dark) 50%, transparent), inset 0 0 2px color-mix(in srgb, var(--tint-light) 30%, transparent);
+    border: 1px solid color-mix(in srgb, var(--tint-light) 20%, transparent);
 }
 
-.status-led.status-ongoing { background-color: #2196F3 !important; }
-.status-led.status-complete { background-color: #4CAF50 !important; }
-.status-led.status-paused { background-color: #FFEB3B !important; }
-.status-led.status-dropped { background-color: #F44336 !important; }
-.status-led.status-not-started { background-color: #FFFFFF !important; }
+.status-led.status-ongoing { background-color: var(--status-ongoing-led) !important; }
+.status-led.status-complete { background-color: var(--status-complete-led) !important; }
+.status-led.status-paused { background-color: var(--status-paused-led) !important; }
+.status-led.status-dropped { background-color: var(--status-dropped-led) !important; }
+.status-led.status-not-started { background-color: var(--status-not-started-led) !important; }
 
 /* Ensure the LED stands out in all themes */
 [data-theme='light'] .status-led {
-    box-shadow: 0 0 2px rgba(0, 0, 0, 0.3);
-    border-color: rgba(0, 0, 0, 0.1);
+    box-shadow: 0 0 2px var(--shadow-color);
+    border-color: color-mix(in srgb, var(--tint-dark) 10%, transparent);
 }
 
-.status-ongoing { background-color: #1c5a8a !important; color: #ffffff !important; }
-.status-complete { background-color: #1e8449 !important; color: #ffffff !important; }
-.status-paused { background-color: #f1c40f !important; color: #000000 !important; }
-.status-dropped { background-color: #c0392b !important; color: #ffffff !important; }
-.status-not-started { background-color: #626567 !important; color: #ffffff !important; }
+.status-ongoing { background-color: var(--status-ongoing-fill) !important; color: var(--status-ongoing-text) !important; }
+.status-complete { background-color: var(--status-complete-fill) !important; color: var(--status-complete-text) !important; }
+.status-paused { background-color: var(--status-paused-fill) !important; color: var(--status-paused-text) !important; }
+.status-dropped { background-color: var(--status-dropped-fill) !important; color: var(--status-dropped-text) !important; }
+.status-not-started { background-color: var(--status-not-started-fill) !important; color: var(--status-not-started-text) !important; }
 .status-untracked { background-color: transparent !important; color: var(--text-secondary) !important; border: 1px dashed var(--border-color) !important; }
  
  .badge-select {
@@ -2896,7 +2936,7 @@ input:focus, select:focus {
 
 .media-detail-icon-button--complete.is-active {
   background: color-mix(in srgb, var(--accent-green) 88%, black 12%);
-  color: #ffffff;
+  color: var(--text-on-fill);
   cursor: default;
 }
 
@@ -2980,7 +3020,7 @@ input:focus, select:focus {
 
 .media-detail-archive-toggle.is-archived .media-detail-archive-icon {
   background: color-mix(in srgb, var(--accent-green) 88%, black 12%);
-  color: #ffffff;
+  color: var(--text-on-fill);
   border-radius: var(--radius-sm);
   padding: 0 .1rem ;
 }
@@ -2994,11 +3034,6 @@ input:focus, select:focus {
   background: color-mix(in srgb, var(--accent-blue) 12%, transparent) !important;
   outline: none;
 }
-
-/* Theme overrides for better contrast if needed */
-[data-theme='light'] .status-ongoing { color: white !important; }
-[data-theme='light'] .status-paused { color: #000 !important; }
-
 
 .heatmap-header {
     display: flex;
@@ -3053,12 +3088,12 @@ input:focus, select:focus {
     width: 100%;
     max-width: 100%;
     min-width: 0;
-    background: rgba(0, 0, 0, 0.2);
+    background: color-mix(in srgb, var(--tint-dark) 20%, transparent);
     backdrop-filter: blur(8px);
     padding: 0.35rem 0.45rem;
     border-radius: var(--radius-lg);
     border: 1px solid var(--border-color);
-    box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.05), var(--shadow-sm);
+    box-shadow: inset 0 1px 1px color-mix(in srgb, var(--tint-light) 5%, transparent), var(--shadow-sm);
 }
 
 .chart-toolbar-group {
@@ -3086,8 +3121,8 @@ input:focus, select:focus {
     right: 0.7rem;
     width: 0.36rem;
     height: 0.36rem;
-    border-right: 1.5px solid var(--text-secondary);
-    border-bottom: 1.5px solid var(--text-secondary);
+    border-right: 0.1rem solid var(--text-secondary);
+    border-bottom: 0.1rem solid var(--text-secondary);
     transform: translateY(-62%) rotate(45deg);
     pointer-events: none;
 }
@@ -3801,7 +3836,7 @@ input:focus, select:focus {
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   border-radius: 20px;
   border: 1px solid var(--border-color);
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+  box-shadow: inset 0 2px 4px color-mix(in srgb, var(--tint-dark) 20%, transparent);
 }
 
 .slider:before {
@@ -3811,15 +3846,15 @@ input:focus, select:focus {
   width: 14px;
   left: 2px;
   bottom: 2px;
-  background-color: #fff;
+  background-color: var(--switch-knob);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   border-radius: 50%;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 2px 4px var(--shadow-color);
 }
 
 input:checked + .slider {
   background-color: var(--accent-green);
-  border-color: rgba(0, 0, 0, 0.1);
+  border-color: color-mix(in srgb, var(--tint-dark) 10%, transparent);
 }
 
 input:checked + .slider:before {
@@ -3990,8 +4025,8 @@ input:checked + .slider:before {
     background:
         radial-gradient(
             circle at bottom right,
-            rgba(0,0,0,0.75) 0%,
-            rgba(0,0,0,0.45) 22%,
+            color-mix(in srgb, var(--tint-dark) 75%, transparent) 0%,
+            color-mix(in srgb, var(--tint-dark) 45%, transparent) 22%,
             transparent 45%
         );
 
@@ -4009,6 +4044,9 @@ input:checked + .slider:before {
     border: none;
     background: none;
     padding: 0;
+
+    /* Sits on cover artwork, not on a themed surface, so it must not follow --text-primary. */
+    color: var(--text-on-fill);
 
     display: flex;
     align-items: center;
@@ -4342,7 +4380,7 @@ input:checked + .slider:before {
     justify-content: center;
     border-top: 1px solid var(--border-color);
     border-bottom: none;
-    box-shadow: 0 -10px 30px rgba(0, 0, 0, 0.22);
+    box-shadow: 0 -10px 30px color-mix(in srgb, var(--tint-dark) 22%, transparent);
   }
 
   #nav-spacer,
@@ -4431,7 +4469,7 @@ input:checked + .slider:before {
     height: 2rem;
     
     
-    box-shadow: 0 16px 28px rgba(0, 0, 0, 0.28);
+    box-shadow: 0 16px 28px color-mix(in srgb, var(--tint-dark) 28%, transparent);
     display: grid;
     justify-items: center;
 
@@ -4841,7 +4879,7 @@ input:checked + .slider:before {
     height: 3.2rem;
     padding: 0;
     border-radius: 999px;
-    box-shadow: 0 16px 28px rgba(0, 0, 0, 0.28);
+    box-shadow: 0 16px 28px color-mix(in srgb, var(--tint-dark) 28%, transparent);
     -webkit-tap-highlight-color: transparent;
     display: flex;
     font-family: initial; /*so it's centered vertically*/
@@ -4873,7 +4911,7 @@ input[type=number] {
 }
 
 input:focus + .slider {
-  box-shadow: 0 0 0 2px rgba(var(--accent-green-rgb, 0, 255, 0), 0.2);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-green) 20%, transparent);
 }
 
 @media (hover:none) {
@@ -4945,7 +4983,7 @@ button:hover{
     border: 1px solid var(--border-color);
     border-radius: var(--radius-lg);
     background: color-mix(in srgb, var(--bg-dark) 94%, black);
-    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
+    box-shadow: 0 24px 80px color-mix(in srgb, var(--tint-dark) 35%, transparent);
 }
 
 .database-recovery-header,
@@ -4969,7 +5007,7 @@ button:hover{
 }
 
 .database-recovery-eyebrow {
-    color: var(--accent-red, #ff7b7b);
+    color: var(--accent-red);
     font-size: 0.76rem;
     font-weight: 700;
     letter-spacing: 0.08em;
@@ -5003,7 +5041,7 @@ button:hover{
     flex: none;
     padding: 0.3rem 0.55rem;
     border-radius: 999px;
-    background: rgba(255, 255, 255, 0.07);
+    background: color-mix(in srgb, var(--tint-light) 7%, transparent);
     color: var(--text-secondary);
     font-size: 0.76rem;
 }
@@ -5023,7 +5061,7 @@ button:hover{
     gap: 1rem;
     padding: 0.45rem 0.6rem;
     border-radius: var(--radius-sm);
-    background: rgba(255, 255, 255, 0.035);
+    background: color-mix(in srgb, var(--tint-light) 3.5%, transparent);
 }
 
 .database-recovery-milestone-name {
@@ -5061,14 +5099,14 @@ button:hover{
 }
 
 .database-recovery-discard-choice {
-    color: var(--accent-red, #ff7b7b);
+    color: var(--accent-red);
 }
 
 .database-recovery-action-panel {
     margin-top: 0.9rem;
     padding: 0.8rem;
     border-radius: var(--radius-sm);
-    background: rgba(255, 255, 255, 0.035);
+    background: color-mix(in srgb, var(--tint-light) 3.5%, transparent);
 }
 
 .database-recovery-action-panel > label {
@@ -5109,7 +5147,7 @@ button:hover{
     border: 1px solid var(--border-color);
     border-radius: var(--radius-md);
     background: color-mix(in srgb, var(--bg-card) 96%, black);
-    box-shadow: 0 14px 34px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 14px 34px var(--shadow-color);
 }
 
 .database-recovery-media-option {
@@ -5127,7 +5165,7 @@ button:hover{
 
 .database-recovery-media-option:hover,
 .database-recovery-media-option.is-highlighted {
-    background: rgba(255, 255, 255, 0.08);
+    background: color-mix(in srgb, var(--tint-light) 8%, transparent);
 }
 
 .database-recovery-media-variant {
@@ -5140,7 +5178,7 @@ button:hover{
 
 .database-recovery-discard-panel,
 .database-recovery-error {
-    color: var(--accent-red, #ff7b7b);
+    color: var(--accent-red);
 }
 
 .database-recovery-error {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4000,6 +4000,14 @@ input:checked + .slider:before {
   padding: 0.8rem 1rem;
   font-size: 0.85rem;
 }
+
+/* Sits on cover artwork, not a themed surface, so it must not follow --text-primary.
+   Must stay outside the width query below: the button renders at every width and its SVG
+   strokes with currentColor. */
+.cover-action {
+    color: var(--text-on-fill);
+}
+
 @media (max-width: 1024px) {
 
   .quick-log-cover {
@@ -4044,9 +4052,6 @@ input:checked + .slider:before {
     border: none;
     background: none;
     padding: 0;
-
-    /* Sits on cover artwork, not on a themed surface, so it must not follow --text-primary. */
-    color: var(--text-on-fill);
 
     display: flex;
     align-items: center;

--- a/src/sync_modal.ts
+++ b/src/sync_modal.ts
@@ -102,7 +102,7 @@ export async function showSyncEnablementWizard(
                 ${hasProfiles
                     ? `<div style="margin-top: 1.25rem; display: flex; flex-direction: column; gap: 0.8rem; overflow: auto; padding-right: 0.25rem;">
                         ${profiles.map((profile, index) => `
-                            <label style="display: flex; gap: 0.9rem; align-items: flex-start; padding: 0.95rem 1rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: rgba(255,255,255,0.02); cursor: pointer;">
+                            <label style="display: flex; gap: 0.9rem; align-items: flex-start; padding: 0.95rem 1rem; border: 1px solid var(--border-color); border-radius: var(--radius-md); background: color-mix(in srgb, var(--tint-light) 2%, transparent); cursor: pointer;">
                                 <input
                                     type="radio"
                                     name="sync-profile-choice"
@@ -118,7 +118,7 @@ export async function showSyncEnablementWizard(
                             </label>
                         `).join('')}
                     </div>`
-                    : `<div style="margin-top: 1.25rem; padding: 1rem 1.1rem; border-radius: var(--radius-md); border: 1px solid rgba(56, 189, 248, 0.28); background: rgba(56, 189, 248, 0.07); color: var(--text-primary);">
+                    : `<div style="margin-top: 1.25rem; padding: 1rem 1.1rem; border-radius: var(--radius-md); border: 1px solid color-mix(in srgb, var(--info) 28%, transparent); background: color-mix(in srgb, var(--info) 7%, transparent); color: var(--text-primary);">
                         This will upload your current local state as the first remote snapshot for this Google account.
                     </div>`}
                 <div style="display: flex; justify-content: flex-end; gap: 0.75rem; margin-top: 1.5rem; flex-wrap: wrap;">
@@ -181,19 +181,19 @@ export async function showSyncAttachPreview(preview: SyncAttachPreview): Promise
                 <p style="margin: 0; color: var(--text-secondary);">
                     Review how <strong style="color: var(--text-primary);">${escapeHTML(preview.profile_name)}</strong> compares with this device before attaching it.
                 </p>
-                <div style="margin-top: 1rem; padding: 0.9rem 1rem; border-radius: var(--radius-md); border: 1px solid rgba(56, 189, 248, 0.24); background: rgba(56, 189, 248, 0.06); color: var(--text-primary);">
+                <div style="margin-top: 1rem; padding: 0.9rem 1rem; border-radius: var(--radius-md); border: 1px solid color-mix(in srgb, var(--info) 24%, transparent); background: color-mix(in srgb, var(--info) 6%, transparent); color: var(--text-primary);">
                     ${escapeHTML(summary)}
                 </div>
                 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.8rem; margin-top: 1.25rem;">
                     ${stats.map((stat, index) => `
-                        <div style="${stats.length % 2 === 1 && index === stats.length - 1 ? 'grid-column: 1 / -1;' : ''} padding: 0.9rem 1rem; border: 1px solid ${stat.highlight ? 'rgba(255, 99, 132, 0.45)' : 'var(--border-color)'}; border-radius: var(--radius-md); background: ${stat.highlight ? 'rgba(255, 99, 132, 0.07)' : 'transparent'};">
+                        <div style="${stats.length % 2 === 1 && index === stats.length - 1 ? 'grid-column: 1 / -1;' : ''} padding: 0.9rem 1rem; border: 1px solid ${stat.highlight ? 'color-mix(in srgb, var(--attention) 45%, transparent)' : 'var(--border-color)'}; border-radius: var(--radius-md); background: ${stat.highlight ? 'color-mix(in srgb, var(--attention) 7%, transparent)' : 'transparent'};">
                             <div style="font-size: 0.8rem; color: var(--text-secondary);">${escapeHTML(stat.label)}</div>
                             <div style="font-size: 1.5rem; font-weight: 700; color: var(--text-primary);">${stat.value}</div>
                         </div>
                     `).join('')}
                 </div>
                 ${preview.potential_duplicate_titles.length > 0
-                    ? `<div style="margin-top: 1rem; padding: 0.95rem 1rem; border-radius: var(--radius-md); border: 1px solid rgba(245, 158, 11, 0.35); background: rgba(245, 158, 11, 0.08);">
+                    ? `<div style="margin-top: 1rem; padding: 0.95rem 1rem; border-radius: var(--radius-md); border: 1px solid color-mix(in srgb, var(--warning) 35%, transparent); background: color-mix(in srgb, var(--warning) 8%, transparent);">
                         <strong style="display: block; margin-bottom: 0.4rem;">Potential duplicate titles</strong>
                         <div style="color: var(--text-secondary); font-size: 0.9rem; margin-bottom: 0.6rem;">These titles appear on both sides with different sync UIDs, so you should sanity-check the merge result after attaching.</div>
                         <ul style="margin: 0; padding-left: 1.2rem; max-height: 160px; overflow: auto;">
@@ -202,7 +202,7 @@ export async function showSyncAttachPreview(preview: SyncAttachPreview): Promise
                     </div>`
                     : ''}
                 ${preview.conflict_count > 0
-                    ? `<div style="margin-top: 1rem; padding: 0.95rem 1rem; border-radius: var(--radius-md); border: 1px solid rgba(255, 99, 132, 0.35); background: rgba(255, 99, 132, 0.08); color: var(--text-primary);">
+                    ? `<div style="margin-top: 1rem; padding: 0.95rem 1rem; border-radius: var(--radius-md); border: 1px solid color-mix(in srgb, var(--attention) 35%, transparent); background: color-mix(in srgb, var(--attention) 8%, transparent); color: var(--text-primary);">
                         Attaching will keep your local data safe, but you will land in conflict review before the merged state can be published.
                     </div>`
                     : ''}

--- a/src/update/modal.ts
+++ b/src/update/modal.ts
@@ -22,7 +22,7 @@ async function showUpdateModal(options: UpdateModalOptions): Promise<void> {
                 <h3 style="margin-bottom: 0.5rem;">${escapeHTML(options.title)}</h3>
                 <p style="margin: 0 0 1rem; color: var(--text-secondary);">${escapeHTML(options.subtitle)}</p>
                 ${options.showBackupWarning
-                    ? '<p style="margin: 0 0 1rem; padding: 0.75rem 0.9rem; border-radius: var(--radius-md); border: 1px solid rgba(255, 166, 0, 0.35); background: rgba(255, 166, 0, 0.08); color: var(--text-primary);">Make sure to back up your data before updating, just in case a migration goes wrong.</p>'
+                    ? '<p style="margin: 0 0 1rem; padding: 0.75rem 0.9rem; border-radius: var(--radius-md); border: 1px solid color-mix(in srgb, var(--warning-bright) 35%, transparent); background: color-mix(in srgb, var(--warning-bright) 8%, transparent); color: var(--text-primary);">Make sure to back up your data before updating, just in case a migration goes wrong.</p>'
                     : ''}
                 <div style="overflow: auto; padding-right: 0.25rem; margin-right: -0.25rem;">
                     ${releaseNotesHtml}

--- a/tests/components/dashboard/ActivityCharts.test.ts
+++ b/tests/components/dashboard/ActivityCharts.test.ts
@@ -3,6 +3,7 @@ import { ActivityCharts } from '../../../src/dashboard/ActivityCharts';
 import { ActivitySummary, Media } from '../../../src/api';
 import type { ChartConfiguration, ChartType } from 'chart.js';
 import Chart from 'chart.js/auto';
+import { applyThemePalette } from '../../helpers/theme_palette';
 
 vi.mock('chart.js/auto', () => ({
     default: vi.fn().mockImplementation(() => ({
@@ -28,6 +29,7 @@ describe('ActivityCharts', () => {
     let onParamChange: (params: Record<string, unknown>) => void;
 
     beforeEach(() => {
+        applyThemePalette();
         container = document.createElement('div');
         onParamChange = vi.fn();
         vi.useRealTimers();

--- a/tests/components/dashboard/HeatmapView.test.ts
+++ b/tests/components/dashboard/HeatmapView.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HeatmapView } from '../../../src/dashboard';
+import { applyThemePalette } from '../../helpers/theme_palette';
 
 describe('HeatmapView', () => {
     let container: HTMLElement;
@@ -7,6 +8,7 @@ describe('HeatmapView', () => {
     let onDateSelect: (dateStr: string) => void;
 
     beforeEach(() => {
+        applyThemePalette();
         container = document.createElement('div');
         onYearChange = vi.fn();
         onDateSelect = vi.fn();

--- a/tests/helpers/theme_palette.ts
+++ b/tests/helpers/theme_palette.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const STYLESHEET_PATH = resolve(process.cwd(), 'src/styles.css');
+const STYLE_ELEMENT_ID = 'test-theme-palette';
+const DEFAULT_THEME = 'pastel-pink';
+
+const ROOT_BLOCK_PATTERN = /:root\s*\{([^}]*)}/;
+
+let cachedStylesheet: string | null = null;
+
+export function applyThemePalette(theme: string = DEFAULT_THEME): void {
+    if (document.getElementById(STYLE_ELEMENT_ID) === null) {
+        cachedStylesheet ??= readFileSync(STYLESHEET_PATH, 'utf8');
+        const rootDeclarations = ROOT_BLOCK_PATTERN.exec(cachedStylesheet)?.[1] ?? '';
+        const element = document.createElement('style');
+        element.id = STYLE_ELEMENT_ID;
+        element.textContent = `${cachedStylesheet}\nbody {${rootDeclarations}}`;
+        document.head.appendChild(element);
+    }
+    document.body.dataset.theme = theme;
+}

--- a/tests/profile/reportcard/report_card_image.test.ts
+++ b/tests/profile/reportcard/report_card_image.test.ts
@@ -5,6 +5,7 @@ import {
     resolveReportCardThemeColors,
 } from '../../../src/profile/reportcard/report_card_image';
 import type { ReportCardImageOptions } from '../../../src/profile/reportcard/report_card_image';
+import { applyThemePalette } from '../../helpers/theme_palette';
 
 const chartMocks = vi.hoisted(() => ({
     create: vi.fn<(canvas: HTMLCanvasElement, config: Record<string, unknown>) => void>(),
@@ -64,19 +65,20 @@ describe('resolveReportCardThemeColors', () => {
         vi.restoreAllMocks();
     });
 
-    it('returns hard-coded fallbacks when CSS variables are absent', () => {
-        vi.spyOn(window, 'getComputedStyle').mockReturnValue({
-            getPropertyValue: () => '',
-        } as unknown as CSSStyleDeclaration);
+    it('resolves every color from the active theme', () => {
+        applyThemePalette();
 
         const colors = resolveReportCardThemeColors();
 
-        expect(colors.backgroundColor).toBe('#1e1e2e');
-        expect(colors.cardBackgroundColor).toBe('#2a2a3e');
-        expect(colors.primaryTextColor).toBe('#cdd6f4');
-        expect(colors.secondaryTextColor).toBe('#a6adc8');
-        expect(colors.borderColor).toBe('#45475a');
-        expect(colors.chartColors).toEqual(['#f4a6b8', '#b8cdda', '#e0bbe4', '#957DAD', '#D291BC']);
+        const resolvedValues = [
+            colors.backgroundColor,
+            colors.cardBackgroundColor,
+            colors.primaryTextColor,
+            colors.secondaryTextColor,
+            colors.borderColor,
+            ...colors.chartColors,
+        ];
+        expect(resolvedValues.filter((value) => value.length === 0)).toEqual([]);
     });
 
     it('returns values from CSS variables when they are set', () => {


### PR DESCRIPTION
This is prep for #120 because it'll likely have to do some custom overrides for specific color tokens, so all the hardcoded colors in the CSS file and in inline styles were problematic. May as well properly fix this up now to build a healthy baseline for the future.

Also discovered and fixed some related things:

- `--accent-green-rgb` was never defined. Replaced with a colormix on `--accent-green`
- `--bg-darkest` was never defined. Replaced with a colormix on `--bg-dark``
- The "Search on Jiten.moe" bit had a hardcoded `ffffff` foreground on a theme-scaling background, now the foreground scales too so it's always visible
- Two overrides in light theme were dead and hence killed
- Five `var(--token, fallback)` fallbacks were dead due to the token being defined in all themes and hence killed
- Four unit round warns in styles.css were fixed